### PR TITLE
jpa 의존성 추가하고 mariadb 전용 드라이버로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,15 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// jpa 연동
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.mariadb.jdbc.Driver
     url: ${RDS_URL}
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
## 개요
jpa 의존성 추가하고 mariadb 전용 드라이버로 변경

## 본문
- build.gradle에 spring-boot-starter-data-jpa, mariadb-java-client 의존성 추가
- application.yml에 driver-class-name을 com.mysql.cj.jdbc.Driver에서 org.mariadb.jdbc.Driver로 수정
- application.yml에 spring.jpa.show.sql=true (쿼리문 보여줌), jpa.properties.hibernate.format_sql=true (쿼리문 예쁜 형태로 보여줌) 옵션 추가
- 환경변수 RDS_URL의 스키마 이름을 naengtal-rds에서 naengtal_rds로 변경해야 함