### PR TITLE
로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ dependencies {
 	// jpa 연동
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+	// jwt
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
@@ -1,0 +1,29 @@
+package com.example.naengtal.global.auth.controller;
+
+import com.example.naengtal.global.auth.dto.SignInRequestDto;
+import com.example.naengtal.global.auth.dto.TokenDto;
+import com.example.naengtal.global.auth.service.AuthenticationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("auth/")
+public class AuthenticationApiController {
+
+    private final AuthenticationService authenticationService;
+
+    @PostMapping("signin")
+    private ResponseEntity<TokenDto> signIn(@Validated @RequestBody SignInRequestDto signInRequestDto) {
+        TokenDto tokenDto = authenticationService.signIn(signInRequestDto.getId(), signInRequestDto.getPassword());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(tokenDto);
+    }
+}

--- a/src/main/java/com/example/naengtal/global/auth/dto/SignInRequestDto.java
+++ b/src/main/java/com/example/naengtal/global/auth/dto/SignInRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.naengtal.global.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignInRequestDto {
+    private String id;
+    private String password;
+}

--- a/src/main/java/com/example/naengtal/global/auth/dto/TokenDto.java
+++ b/src/main/java/com/example/naengtal/global/auth/dto/TokenDto.java
@@ -1,0 +1,11 @@
+package com.example.naengtal.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TokenDto {
+    private String accessToken;
+    private long accessTokenValidateTime;
+}

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.example.naengtal.global.auth.jwt;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write("INVALID_TOKEN");
+    }
+}

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.example.naengtal.global.auth.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // JWT 토큰의 인증 정보(Authentication 객체)를 SecurityContext 에 저장
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token)
+                && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest httpServletRequest) {
+        String token = httpServletRequest.getHeader(AUTHORIZATION_HEADER);
+        if (token != null && token.startsWith(BEARER_PREFIX)) {
+            return token.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
@@ -59,7 +59,7 @@ public class JwtTokenProvider {
             parseClaims(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.error("Invalid JWT token");
+            log.error("Invalid JWT Token");
         } catch (ExpiredJwtException e) {
             log.error("expired token");
         } catch (UnsupportedJwtException e) {
@@ -74,19 +74,8 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(token);
         List<GrantedAuthority> authorities = parseAuthorities(claims);
 
-        validateAuthority(authorities);
-
         UserDetails principal = new User(claims.getSubject(), "", authorities);
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
-    }
-
-    private void validateAuthority(List<GrantedAuthority> authorities) {
-        for (GrantedAuthority authority : authorities) {
-            if (authority.getAuthority().equals("ROLE_USER")) {
-                return;
-            }
-        }
-        throw new RuntimeException("Invalid Authority");
     }
 
     private Claims parseClaims(String token) {
@@ -98,8 +87,16 @@ public class JwtTokenProvider {
     }
 
     private List<GrantedAuthority> parseAuthorities(Claims claims) {
-        return Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(""))
+        validateAuthorities(claims);
+
+        return Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
+    }
+
+    private void validateAuthorities(Claims claims) {
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("NO AUTHORITIES");
+        }
     }
 }

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,105 @@
+package com.example.naengtal.global.auth.jwt;
+
+import com.example.naengtal.global.auth.dto.TokenDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+    @Value("${jwt.validate-in-seconds}")
+    private long accessTokenValidateTime;
+    private static final String AUTHORITIES_KEY = "auth";
+    private Key key;
+
+    @PostConstruct
+    private void init() {
+        key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        accessTokenValidateTime *= 1000;
+    }
+
+    public TokenDto generateToken(Authentication authentication) {
+        long now = (new Date()).getTime();
+
+        String token = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authentication.getAuthorities()
+                        .stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .collect(Collectors.joining(",")))
+                .setExpiration(new Date(now + accessTokenValidateTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+        return new TokenDto(token, now + accessTokenValidateTime);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT token");
+        } catch (ExpiredJwtException e) {
+            log.error("expired token");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty.");
+        }
+        return false;
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        List<GrantedAuthority> authorities = parseAuthorities(claims);
+
+        validateAuthority(authorities);
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    private void validateAuthority(List<GrantedAuthority> authorities) {
+        for (GrantedAuthority authority : authorities) {
+            if (authority.getAuthority().equals("ROLE_USER")) {
+                return;
+            }
+        }
+        throw new RuntimeException("Invalid Authority");
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private List<GrantedAuthority> parseAuthorities(Claims claims) {
+        return Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(""))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtUserDetails.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtUserDetails.java
@@ -1,0 +1,63 @@
+package com.example.naengtal.global.auth.jwt;
+
+import com.example.naengtal.domain.member.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JwtUserDetails implements UserDetails {
+
+    private final Member member;
+    private final List<String> roles = new ArrayList<>();
+
+    public JwtUserDetails(Member member) {
+        this.member = member;
+        roles.add("ROLE_USER");
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getId();
+    }
+
+    // 계정 만료 여부
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    // 계정 잠김 여부
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    // 비밀번호 만료 여부
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    // 사용자 활성화 여부
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtUserDetailsService.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.example.naengtal.global.auth.jwt;
+
+import com.example.naengtal.domain.member.dao.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class JwtUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        return memberRepository.findById(id)
+                .map(JwtUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("ID does not exist"));
+    }
+}

--- a/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
+++ b/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
@@ -1,0 +1,37 @@
+package com.example.naengtal.global.auth.service;
+
+import com.example.naengtal.global.auth.dto.TokenDto;
+import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthenticationService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    public TokenDto signIn(String id, String password) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, password);
+
+        // 실제 검증(사용자 비밀번호 체크)
+        // authenticate 메서드 실행 시 JwtUserDetailsService 에서 만든 loadUserByName 메서드 실행
+        Authentication authentication = getAuthentication(authenticationToken);
+
+        return jwtTokenProvider.generateToken(authentication);
+    }
+
+    private Authentication getAuthentication(UsernamePasswordAuthenticationToken authenticationToken) {
+        try {
+            return authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
@@ -1,26 +1,41 @@
 package com.example.naengtal.global.config;
 
+import com.example.naengtal.global.auth.jwt.JwtAuthenticationEntryPoint;
+import com.example.naengtal.global.auth.jwt.JwtAuthenticationFilter;
+import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtTokenProvider jwtTokenProvider;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf().disable()        // csrf 방지
-            .formLogin().disable()
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS); // 세션 사용x(jwt 사용)
+                .formLogin().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS); // 세션 사용x(jwt 사용)
 
         http.authorizeRequests()
-            .antMatchers("/account/signup").permitAll(); // 모든 요청 허가
+                .antMatchers("/account/signup").permitAll() // 모든 요청 허가
+                .antMatchers("/auth/signin").permitAll()
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling()
+                .authenticationEntryPoint(new JwtAuthenticationEntryPoint());
+
 
         return http.build();
     }

--- a/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
         http.authorizeRequests()
                 .antMatchers("/account/signup").permitAll() // 모든 요청 허가
                 .antMatchers("/auth/signin").permitAll()
+                .anyRequest().hasRole("USER")
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  validate-in-seconds: 7776000


### PR DESCRIPTION
## 개요
로그인 기능 구현
jwt 의존성 추가

## 작업사항
- jwt 의존성 추가
- 로그인 요청 시 @Validate으로 리퀘스트 객체 검사
- 이 후, UsernamePasswordAuthenticationToken 객체 생성하여 AuthenticationManagerBuilder의 authenticate()로 아이디, 비밀번호를 검사한다. 검사가 통과된다면 JwtTokenProvider로 토큰을 생성하여 리턴해준다.
- 리턴하는 정보에는 AccessToken과 AcessTokenValidateTime이 들어 있다.
- 에러처리는 후에 변경 예정

## 변경로직
- 환경변수 추가(JWT_SECRET_KEY) -> 카카오톡 확인 필요
- SecurityConfig에 커스텀한 filter 추가
