### PR TITLE
에러 핸들러 구현

### DIFF
--- a/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
@@ -1,6 +1,6 @@
 package com.example.naengtal.domain.member.controller;
 
-import com.example.naengtal.domain.member.dto.SignUpDto;
+import com.example.naengtal.domain.member.dto.SignUpRequestDto;
 import com.example.naengtal.domain.member.service.AccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,8 +19,8 @@ public class AccountApiController {
     private final AccountService accountService;
 
     @PostMapping("signup")
-    public ResponseEntity<String> signUp(@Validated @RequestBody SignUpDto signUpDto) {
-        accountService.saveMember(signUpDto);
+    public ResponseEntity<String> signUp(@Validated @RequestBody SignUpRequestDto signUpRequestDto) {
+        accountService.saveMember(signUpRequestDto);
         return ResponseEntity.status(HttpStatus.OK)
                 .body("success");
     }

--- a/src/main/java/com/example/naengtal/domain/member/dto/SignUpRequestDto.java
+++ b/src/main/java/com/example/naengtal/domain/member/dto/SignUpRequestDto.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.Size;
 
 @Getter
 @Setter
-public class SignUpDto {
+public class SignUpRequestDto {
 
     @NotBlank(message = "NAME_IS_MANDATORY")
     @Size(min = 1, max = 10)

--- a/src/main/java/com/example/naengtal/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/example/naengtal/domain/member/exception/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.naengtal.domain.member.exception;
+
+import com.example.naengtal.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    UNAVAILABLE_ID(HttpStatus.BAD_REQUEST, "Unavailable id"),
+    WRONG_CONFIRM_PASSWORD(HttpStatus.BAD_REQUEST, "Wrong confirm password"),
+    ;
+
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
@@ -3,7 +3,7 @@ package com.example.naengtal.domain.member.service;
 import com.example.naengtal.domain.fridge.entity.Fridge;
 import com.example.naengtal.domain.fridge.repository.FridgeRepository;
 import com.example.naengtal.domain.member.dao.MemberRepository;
-import com.example.naengtal.domain.member.dto.SignUpDto;
+import com.example.naengtal.domain.member.dto.SignUpRequestDto;
 import com.example.naengtal.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -22,14 +22,14 @@ public class AccountService {
 
     private final PasswordEncoder passwordEncoder;
 
-    public void saveMember(SignUpDto signUpDto) {
+    public void saveMember(SignUpRequestDto signUpRequestDto) {
         // id 중복 검사
-        memberRepository.findById(signUpDto.getId()).ifPresent(a ->
+        memberRepository.findById(signUpRequestDto.getId()).ifPresent(a ->
             System.out.println("id already exist")
         );
 
         // 비밀번호와 비밀번호 확인 일치하는지 검사
-        if (!signUpDto.getPassword().equals(signUpDto.getConfirmPassword()))
+        if (!signUpRequestDto.getPassword().equals(signUpRequestDto.getConfirmPassword()))
             System.out.println("wrong confirm password");
 
         // 냉장고 생성
@@ -38,9 +38,9 @@ public class AccountService {
 
         // 디비에 저장장
         memberRepository.save(Member.builder()
-                .id(signUpDto.getId())
-                .name(signUpDto.getName())
-                .password(passwordEncoder.encode(signUpDto.getPassword()))
+                .id(signUpRequestDto.getId())
+                .name(signUpRequestDto.getName())
+                .password(passwordEncoder.encode(signUpRequestDto.getPassword()))
                 .fridge(fridge)
                 .build());
     }

--- a/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
@@ -5,11 +5,15 @@ import com.example.naengtal.domain.fridge.repository.FridgeRepository;
 import com.example.naengtal.domain.member.dao.MemberRepository;
 import com.example.naengtal.domain.member.dto.SignUpRequestDto;
 import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+
+import static com.example.naengtal.domain.member.exception.MemberErrorCode.UNAVAILABLE_ID;
+import static com.example.naengtal.domain.member.exception.MemberErrorCode.WRONG_CONFIRM_PASSWORD;
 
 @Service
 @Transactional
@@ -24,13 +28,13 @@ public class AccountService {
 
     public void saveMember(SignUpRequestDto signUpRequestDto) {
         // id 중복 검사
-        memberRepository.findById(signUpRequestDto.getId()).ifPresent(a ->
-            System.out.println("id already exist")
-        );
+        memberRepository.findById(signUpRequestDto.getId()).ifPresent(a -> {
+            throw new RestApiException(UNAVAILABLE_ID);
+        });
 
         // 비밀번호와 비밀번호 확인 일치하는지 검사
         if (!signUpRequestDto.getPassword().equals(signUpRequestDto.getConfirmPassword()))
-            System.out.println("wrong confirm password");
+            throw new RestApiException(WRONG_CONFIRM_PASSWORD);
 
         // 냉장고 생성
         Fridge fridge = new Fridge();

--- a/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
+++ b/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.naengtal.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/naengtal/global/error/ErrorCode.java
+++ b/src/main/java/com/example/naengtal/global/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.example.naengtal.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String name();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/example/naengtal/global/error/ErrorResponseDto.java
+++ b/src/main/java/com/example/naengtal/global/error/ErrorResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.naengtal.global.error;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponseDto {
+
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/example/naengtal/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/naengtal/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.example.naengtal.global.error;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<ErrorResponseDto> handleRestApiException(RestApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode);
+    }
+
+//    패키지 구조 같은 거 숨기는 목적. 근데 개발 단계에서는 오류잡을 때 불편하므로 주석처리 해 놓았음
+//    @ExceptionHandler({Exception.class})
+//    public ResponseEntity<Object> handleAllException(Exception e) {
+//        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+//        return handleExceptionInternal(errorCode);
+//    }
+
+    private ResponseEntity<ErrorResponseDto> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorResponseDto makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponseDto.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/example/naengtal/global/error/RestApiException.java
+++ b/src/main/java/com/example/naengtal/global/error/RestApiException.java
@@ -1,0 +1,11 @@
+package com.example.naengtal.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private ErrorCode errorCode;
+}


### PR DESCRIPTION
## 개요
- 에러 핸들러 구현
- 회원가입 에러 처리 수정

## 작업사항
- @RestControllerAdvice, @ExceptionHandler, ErrorCode 클래스, ErrorResponseDto 클래스, RestApiException 클래스로 에러 핸들러 구현
- 사용 방법
  - 우선 ErrorCode를 implements하는 enum 클래스를 생성
  - 에러 처리 해야 하는 부분에서 enum 값을 인자로 넣어 RestApiException을 날림

## 변경로직
- MemberErrorCode 클래스 생성해서 AccountService 클래스의 에러 처리 방법 수정
- SignUpDto 클래스의 이름을 SignUpReqeustDtp로 변경
