### PR TITLE
로그아웃 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.9'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.9'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.example.naengtal'
@@ -9,40 +9,43 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// jpa 연동
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    // jpa 연동
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
-	// jwt
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    // test 시 사용할 DB(h2)
+    runtimeOnly 'com.h2database:h2'
 
-	// redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 jar {
-	enabled = false
+    enabled = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
@@ -4,12 +4,12 @@ import com.example.naengtal.global.auth.dto.SignInRequestDto;
 import com.example.naengtal.global.auth.dto.TokenDto;
 import com.example.naengtal.global.auth.service.AuthenticationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import static com.example.naengtal.global.auth.jwt.JwtAuthenticationFilter.AUTHORIZATION_HEADER;
 import static com.example.naengtal.global.auth.jwt.JwtAuthenticationFilter.BEARER_PREFIX;
 
 
@@ -28,7 +28,7 @@ public class AuthenticationApiController {
     }
 
     @PostMapping("signout")
-    private ResponseEntity<String> signOut(@RequestHeader(AUTHORIZATION_HEADER) String authorization){
+    private ResponseEntity<String> signOut(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
         authenticationService.signOut(authorization.substring(BEARER_PREFIX.length()));
         return ResponseEntity.status(HttpStatus.OK)
                 .body("signout success!");

--- a/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
@@ -7,10 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.naengtal.global.auth.jwt.JwtAuthenticationFilter.AUTHORIZATION_HEADER;
+import static com.example.naengtal.global.auth.jwt.JwtAuthenticationFilter.BEARER_PREFIX;
 
 
 @RestController
@@ -25,5 +25,12 @@ public class AuthenticationApiController {
         TokenDto tokenDto = authenticationService.signIn(signInRequestDto.getId(), signInRequestDto.getPassword());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(tokenDto);
+    }
+
+    @PostMapping("signout")
+    private ResponseEntity<String> signOut(@RequestHeader(AUTHORIZATION_HEADER) String authorization){
+        authenticationService.signOut(authorization.substring(BEARER_PREFIX.length()));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("signout success!");
     }
 }

--- a/src/main/java/com/example/naengtal/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/naengtal/global/auth/exception/AuthErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.naengtal.global.auth.exception;
+
+import com.example.naengtal.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN"),
+    WRONG_ID_OR_PASSWORD(HttpStatus.BAD_REQUEST, "WRONG_ID_OR_PASSWORD");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,6 @@
 package com.example.naengtal.global.auth.jwt;
 
-import org.springframework.http.HttpStatus;
+import com.example.naengtal.global.error.ErrorResponseDto;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -9,11 +9,17 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static com.example.naengtal.global.auth.exception.AuthErrorCode.INVALID_TOKEN;
+
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.getWriter().write("INVALID_TOKEN");
+        response.setStatus(INVALID_TOKEN.getHttpStatus().value());
+
+        response.getWriter().write(ErrorResponseDto.builder()
+                .code(INVALID_TOKEN.getHttpStatus().toString())
+                .message(INVALID_TOKEN.getMessage())
+                .build().toString());
     }
 }

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.example.naengtal.global.auth.jwt;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -15,7 +16,6 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest httpServletRequest) {
-        String token = httpServletRequest.getHeader(AUTHORIZATION_HEADER);
+        String token = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
         if (token != null && token.startsWith(BEARER_PREFIX)) {
             return token.substring(BEARER_PREFIX.length());
         }

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.example.naengtal.global.auth.jwt;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -18,6 +19,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     // JWT 토큰의 인증 정보(Authentication 객체)를 SecurityContext 에 저장
     @Override
@@ -25,7 +27,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (StringUtils.hasText(token)
-                && jwtTokenProvider.validateToken(token)) {
+                && jwtTokenProvider.validateToken(token)
+                && redisTemplate.opsForValue().get(token) == null) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
@@ -78,6 +78,11 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
     }
 
+    public long getExpiration(String token) {
+        return parseClaims(token).getExpiration()
+                .getTime();
+    }
+
     private Claims parseClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtTokenProvider.java
@@ -30,7 +30,7 @@ public class JwtTokenProvider {
     private String secretKey;
     @Value("${jwt.validate-in-seconds}")
     private long accessTokenValidateTime;
-    private static final String AUTHORITIES_KEY = "auth";
+    public static final String AUTHORITIES_KEY = "auth";
     private Key key;
 
     @PostConstruct

--- a/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
+++ b/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
@@ -2,6 +2,7 @@ package com.example.naengtal.global.auth.service;
 
 import com.example.naengtal.global.auth.dto.TokenDto;
 import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
+import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -12,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
+import static com.example.naengtal.global.auth.exception.AuthErrorCode.WRONG_ID_OR_PASSWORD;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,7 +39,7 @@ public class AuthenticationService {
         try {
             return authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         } catch (Exception e) {
-            throw new RuntimeException(e.getMessage());
+            throw new RestApiException(WRONG_ID_OR_PASSWORD);
         }
     }
 

--- a/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
+++ b/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
@@ -3,11 +3,15 @@ package com.example.naengtal.global.auth.service;
 import com.example.naengtal.global.auth.dto.TokenDto;
 import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional(readOnly = true)
@@ -16,6 +20,7 @@ public class AuthenticationService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public TokenDto signIn(String id, String password) {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, password);
@@ -33,5 +38,13 @@ public class AuthenticationService {
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage());
         }
+    }
+
+    public void signOut(String accessToken) {
+        redisTemplate.opsForValue()
+                .set(accessToken,
+                        "signOut",
+                        jwtTokenProvider.getExpiration(accessToken) - (new Date()).getTime(),
+                        TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/com/example/naengtal/global/config/RedisConfig.java
+++ b/src/main/java/com/example/naengtal/global/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.example.naengtal.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        // 직접 데이터 조회 시 알아볼 수 있게 설정
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -20,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,7 +34,7 @@ public class SecurityConfig {
                 .antMatchers("/auth/signin").permitAll()
                 .anyRequest().hasRole("USER")
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate),
                         UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling()
                 .authenticationEntryPoint(new JwtAuthenticationEntryPoint());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  redis:
+    host: localhost
+    port: 6379
 
 jwt:
   secret: ${JWT_SECRET_KEY}

--- a/src/test/java/com/example/naengtal/AuthenticationApiControllerTest/SecurityTest.java
+++ b/src/test/java/com/example/naengtal/AuthenticationApiControllerTest/SecurityTest.java
@@ -1,0 +1,157 @@
+package com.example.naengtal.AuthenticationApiControllerTest;
+
+import com.example.naengtal.domain.member.dao.MemberRepository;
+import com.example.naengtal.domain.member.dto.SignUpRequestDto;
+import com.example.naengtal.domain.member.service.AccountService;
+import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
+import com.example.naengtal.global.auth.service.AuthenticationService;
+import com.example.naengtal.global.error.RestApiException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Date;
+
+import static com.example.naengtal.global.auth.jwt.JwtAuthenticationFilter.BEARER_PREFIX;
+import static com.example.naengtal.global.auth.jwt.JwtTokenProvider.AUTHORITIES_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+public class SecurityTest {
+
+    @Autowired
+    private AuthenticationService authenticationService;
+    @Autowired
+    private AccountService accountService;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @BeforeEach
+    void beforeEach() {
+        // 회원 가입
+        SignUpRequestDto signUpRequestDto = new SignUpRequestDto();
+        signUpRequestDto.setId("test");
+        signUpRequestDto.setPassword("test1234");
+        signUpRequestDto.setConfirmPassword("test1234");
+        signUpRequestDto.setName("test");
+
+        accountService.saveMember(signUpRequestDto);
+    }
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.findById("test").ifPresent(member -> memberRepository.delete(member));
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_success() {
+        String accessToken = authenticationService.signIn("test", "test1234").getAccessToken();
+
+        assertThat(accessToken).isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그인 실패")
+    void login_fail() {
+        assertThatThrownBy(() -> authenticationService.signIn("test", "test1233")).isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("accessToken 검증 성공")
+    void access_token_validate_success() {
+        String accessToken = authenticationService.signIn("test", "test1234").getAccessToken();
+
+        assertThat(jwtTokenProvider.validateToken(accessToken)).isTrue();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰으로 접근 시 실패")
+    void access_token_expired_fail() {
+        long now = new Date().getTime();
+
+        String expiredToken = Jwts.builder()
+                .setSubject("test")
+                .claim(AUTHORITIES_KEY, "ROLE_USER")
+                .setExpiration((new Date(now - 1)))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThat(jwtTokenProvider.validateToken(expiredToken)).isFalse();
+    }
+
+    @Test
+    @DisplayName("시크릿 키가 틀린 토큰 정보일 경우 실패")
+    void access_token_wrong_secret_key_fail() {
+        long now = new Date().getTime();
+
+        String accessToken = Jwts.builder()
+                .setSubject("test")
+                .claim(AUTHORITIES_KEY, "ROLE_USER")
+                .setExpiration((new Date(now + 1000 * 60 * 2)))
+                .signWith(Keys.hmacShaKeyFor("WrongKey_잘못된키입니다_WrongKey".getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThat(jwtTokenProvider.validateToken(accessToken)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Role이 다를 경우 실패")
+    void access_token_wrong_role_fail() throws Exception {
+        long now = new Date().getTime();
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        String accessToken = Jwts.builder()
+                .setSubject("test")
+                .claim(AUTHORITIES_KEY, "ROLE_WRONG")
+                .setExpiration((new Date(now + 1000 * 60 * 2)))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+        httpHeaders.add(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + " " + accessToken);
+
+        mockMvc.perform(post("/auth/signout")
+                        .headers(httpHeaders))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("로그아웃_성공")
+    void signOutTest() throws Exception {
+        String accessToken = authenticationService.signIn("test", "test1234").getAccessToken();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken);
+
+        authenticationService.signOut(accessToken);
+
+
+        mockMvc.perform(post("/auth/signout")
+                        .headers(httpHeaders))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## 개요
- 로그아웃 구현
- 인증 관련 테스트 코드 작성

## 작업사항
- "/auth/signout"로 접근 시 Authentication 헤더로 온 토큰을 Redis 서버에 key로 올린다. 따라서 이후 해당 토큰으로 접근 시 JwtAuthenticationFilter에서 Redis 서버에 해당 토큰이 존재하는 지 확인하여 존재하면 인증 실패, 존재하지 않으면 인증 성공으로 처리한다.
- 테스트코드는 @SpringBootTest를 사용하여 작성했다.(인증 유무를 판단하기 위해서 MockMvc를 사용해야했기 때문)

## 변경로직
- 에러 처리 구현(RestApiException과 ErrorCode 상속한 enum 사용)
