### PR TITLE
Swagger 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
+// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
@@ -3,6 +3,7 @@ package com.example.naengtal.global.auth.controller;
 import com.example.naengtal.global.auth.dto.SignInRequestDto;
 import com.example.naengtal.global.auth.dto.TokenDto;
 import com.example.naengtal.global.auth.service.AuthenticationService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -28,7 +29,7 @@ public class AuthenticationApiController {
     }
 
     @PostMapping("signout")
-    private ResponseEntity<String> signOut(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+    private ResponseEntity<String> signOut(@Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
         authenticationService.signOut(authorization.substring(BEARER_PREFIX.length()));
         return ResponseEntity.status(HttpStatus.OK)
                 .body("signout success!");

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,8 @@
 package com.example.naengtal.global.auth.jwt;
 
 import com.example.naengtal.global.error.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -16,10 +18,15 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         response.setStatus(INVALID_TOKEN.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        response.getWriter().write(ErrorResponseDto.builder()
-                .code(INVALID_TOKEN.getHttpStatus().toString())
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+                .code(INVALID_TOKEN.name())
                 .message(INVALID_TOKEN.getMessage())
-                .build().toString());
+                .build();
+
+        String errorCode = new ObjectMapper().writeValueAsString(errorResponseDto);
+
+        response.getWriter().write(errorCode);
     }
 }

--- a/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/naengtal/global/auth/jwt/JwtAuthenticationFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/naengtal/global/config/SecurityConfig.java
@@ -22,6 +22,12 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
+    private static final String[] SWAGGER_LIST = {
+            // swagger 접근 허용
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,6 +38,7 @@ public class SecurityConfig {
         http.authorizeRequests()
                 .antMatchers("/account/signup").permitAll() // 모든 요청 허가
                 .antMatchers("/auth/signin").permitAll()
+                .antMatchers(SWAGGER_LIST).permitAll()
                 .anyRequest().hasRole("USER")
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate),

--- a/src/main/java/com/example/naengtal/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/naengtal/global/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.example.naengtal.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@EnableWebMvc
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Naengtal API")
+                .description("Naengtal API 명세서입니다.");
+
+        // Security 스키마 설정
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("Authorization")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        // Security 요청 설정
+        SecurityRequirement addSecurityItem = new SecurityRequirement().addList("Authorization");
+
+
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(addSecurityItem)
+                .components(new Components().addSecuritySchemes("Authorization", bearerAuth));
+    }
+}


### PR DESCRIPTION
## 개요
- Swagger API 연동

## 작업사항
- Swagger API를 연결하여 "/swagger-ui.html"에서 api 문서를 볼 수 있음.

## 변경로직
- accessToken 인증 거부 시 INVALID_TOKEN 에러가 리턴되어야 되는데 제대로 리턴되지 않는 것을 확인하여 JwtAuthenticationEntryPoint 클래스를 수정함
