### PR TITLE
냉장고 공유 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,11 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-
-// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui
+    // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.7'
+
+    // firebase
+    implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/naengtal/NaengtalApplication.java
+++ b/src/main/java/com/example/naengtal/NaengtalApplication.java
@@ -2,8 +2,10 @@ package com.example.naengtal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NaengtalApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/naengtal/domain/alarm/dto/FcmInvitationDto.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/dto/FcmInvitationDto.java
@@ -1,0 +1,18 @@
+package com.example.naengtal.domain.alarm.dto;
+
+import com.example.naengtal.global.common.service.FcmType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class FcmInvitationDto {
+
+    private String title;
+    private String body;
+    private FcmType type;
+}

--- a/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
@@ -1,9 +1,7 @@
 package com.example.naengtal.domain.alarm.entity;
 
 import com.example.naengtal.domain.member.entity.Member;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,6 +13,8 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @EntityListeners(AuditingEntityListener.class)
 public class Alarm {
 
@@ -31,10 +31,14 @@ public class Alarm {
     private AlarmType type;
 
     @CreatedDate
-    @Column(name = "create_at")
-    private LocalDateTime createAt;
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     @ManyToOne
     @JoinColumn(name = "id")
     private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "inviter_id")
+    private Member inviter;
 }

--- a/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
@@ -26,10 +26,6 @@ public class Alarm {
     @Column(name = "text")
     private String text;
 
-    @Column(name = "type")
-    @Enumerated(EnumType.STRING)
-    private AlarmType type;
-
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 public class Alarm {
 
     @Id
-    @Column(name = "id", nullable = false)
+    @Column(name = "alarm_id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 

--- a/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/entity/Alarm.java
@@ -1,0 +1,40 @@
+package com.example.naengtal.domain.alarm.entity;
+
+import com.example.naengtal.domain.member.entity.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "alarm")
+@Getter
+@Setter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Alarm {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "text")
+    private String text;
+
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    private AlarmType type;
+
+    @CreatedDate
+    @Column(name = "create_at")
+    private LocalDateTime createAt;
+
+    @ManyToOne
+    @JoinColumn(name = "id")
+    private Member member;
+}

--- a/src/main/java/com/example/naengtal/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/entity/AlarmType.java
@@ -1,6 +1,0 @@
-package com.example.naengtal.domain.alarm.entity;
-
-public enum AlarmType {
-    INVITATION,
-    CLOSE_TO_EXPIRATION
-}

--- a/src/main/java/com/example/naengtal/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/entity/AlarmType.java
@@ -1,0 +1,6 @@
+package com.example.naengtal.domain.alarm.entity;
+
+public enum AlarmType {
+    INVITATION,
+    CLOSE_TO_EXPIRATION
+}

--- a/src/main/java/com/example/naengtal/domain/alarm/exception/AlarmErrorCode.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/exception/AlarmErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.naengtal.domain.alarm.exception;
+
+import com.example.naengtal.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AlarmErrorCode implements ErrorCode {
+
+    ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "alarm not found"),
+    NOT_OWN_ALARM(HttpStatus.BAD_REQUEST, "not own alarm"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/naengtal/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/repository/AlarmRepository.java
@@ -1,0 +1,9 @@
+package com.example.naengtal.domain.alarm.repository;
+
+import com.example.naengtal.domain.alarm.entity.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlarmRepository extends JpaRepository<Alarm, Integer> {
+}

--- a/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
+++ b/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
@@ -1,11 +1,13 @@
 package com.example.naengtal.domain.fridge.entity;
 
+import com.example.naengtal.domain.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Table(name = "Fridge")
@@ -19,4 +21,7 @@ public class Fridge {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "fridge_id", nullable = false)
     int id;
+
+    @OneToMany(mappedBy = "fridge")
+    List<Member> sharedMembers;
 }

--- a/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
+++ b/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -23,5 +24,5 @@ public class Fridge {
     private int id;
 
     @OneToMany(mappedBy = "fridge")
-    private List<Member> sharedMembers;
+    private List<Member> sharedMembers = new ArrayList<>();
 }

--- a/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
+++ b/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
@@ -25,4 +25,6 @@ public class Fridge {
 
     @OneToMany(mappedBy = "fridge")
     private List<Member> sharedMembers = new ArrayList<>();
+
+    public Fridge(int id) { this.id = id; }
 }

--- a/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
+++ b/src/main/java/com/example/naengtal/domain/fridge/entity/Fridge.java
@@ -20,8 +20,8 @@ public class Fridge {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "fridge_id", nullable = false)
-    int id;
+    private int id;
 
     @OneToMany(mappedBy = "fridge")
-    List<Member> sharedMembers;
+    private List<Member> sharedMembers;
 }

--- a/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
@@ -21,6 +21,7 @@ public class AccountApiController {
     @PostMapping("signup")
     public ResponseEntity<SignUpResponseDto> signUp(@Validated @RequestBody SignUpRequestDto signUpRequestDto) {
         SignUpResponseDto dto = accountService.saveMember(signUpRequestDto);
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(dto);
     }
@@ -28,6 +29,7 @@ public class AccountApiController {
     @DeleteMapping("delete")
     public ResponseEntity<String> withdrawal(@LoggedInUser Member member) {
         accountService.deleteMember(member);
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body("success");
     }

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-public class FridgeShareController {
+public class FridgeShareApiController {
 
     private final MemberSearchService memberSearchService;
 
@@ -29,6 +29,12 @@ public class FridgeShareController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberSearchService.search(inviter, nameOrId));
 
+    }
+
+    @GetMapping("get/sharedmembers")
+    public ResponseEntity<List<MemberResponseDto>> getSharedMembers(@Parameter(hidden = true) @LoggedInUser Member member) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(memberSearchService.searchSharedMembers(member));
     }
 
     @GetMapping("invite/{member_id}")

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
@@ -2,6 +2,7 @@ package com.example.naengtal.domain.member.controller;
 
 import com.example.naengtal.domain.member.dto.MemberResponseDto;
 import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.domain.member.service.MemberInvitationService;
 import com.example.naengtal.domain.member.service.MemberSearchService;
 import com.example.naengtal.global.common.annotation.LoggedInUser;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,11 +21,22 @@ public class FridgeShareController {
 
     private final MemberSearchService memberSearchService;
 
+    private final MemberInvitationService memberInvitationService;
+
     @GetMapping("search/{name_or_id}")
     public ResponseEntity<List<MemberResponseDto>> search(@Parameter(hidden = true) @LoggedInUser Member inviter,
                                                           @PathVariable("name_or_id") String nameOrId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberSearchService.search(inviter, nameOrId));
 
+    }
+
+    @GetMapping("invite/{member_id}")
+    public ResponseEntity<String> invite(@Parameter(hidden = true) @LoggedInUser Member inviter,
+                                         @PathVariable("member_id") String inviteeId) {
+        memberInvitationService.invite(inviter, inviteeId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("success");
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
@@ -39,4 +39,13 @@ public class FridgeShareController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body("success");
     }
+
+    @GetMapping("accept/{alarm_id}")
+    public ResponseEntity<String> accept(@Parameter(hidden = true) @LoggedInUser Member invitee,
+                                         @PathVariable("alarm_id") int alarmId) {
+        memberInvitationService.accept(invitee, alarmId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("success");
+    }
 }

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
@@ -1,11 +1,30 @@
 package com.example.naengtal.domain.member.controller;
 
+import com.example.naengtal.domain.member.dto.MemberResponseDto;
+import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.domain.member.service.MemberSearchService;
+import com.example.naengtal.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("share/")
 @RequiredArgsConstructor
 public class FridgeShareController {
+
+    private final MemberSearchService memberSearchService;
+
+    @GetMapping("search/{name_or_id}")
+    public ResponseEntity<List<MemberResponseDto>> search(@Parameter(hidden = true) @LoggedInUser Member inviter,
+                                                          @PathVariable("name_or_id") String nameOrId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(memberSearchService.search(inviter, nameOrId));
+
+    }
 }

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareController.java
@@ -1,0 +1,11 @@
+package com.example.naengtal.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("share/")
+@RequiredArgsConstructor
+public class FridgeShareController {
+}

--- a/src/main/java/com/example/naengtal/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/example/naengtal/domain/member/dao/MemberRepository.java
@@ -4,6 +4,10 @@ import com.example.naengtal.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
+
+    List<Member> findByNameContainsOrIdContains(String name, String id);
 }

--- a/src/main/java/com/example/naengtal/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/member/dto/MemberResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.naengtal.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MemberResponseDto {
+
+    String name;
+    String id;
+    boolean isSharing;
+}

--- a/src/main/java/com/example/naengtal/domain/member/entity/Member.java
+++ b/src/main/java/com/example/naengtal/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.example.naengtal.domain.member.entity;
 
+import com.example.naengtal.domain.alarm.entity.Alarm;
 import com.example.naengtal.domain.fridge.entity.Fridge;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "member")
@@ -28,6 +31,13 @@ public class Member {
     @ManyToOne
     @JoinColumn(name = "fridge_id", nullable = false)
     private Fridge fridge;
+
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
+    private List<Alarm> alarm = new ArrayList<>();
+
+    @OneToMany(mappedBy = "inviter", orphanRemoval = true)
+    private List<Alarm> relatedAlarms = new ArrayList<>();
+
 
     @Builder
     public Member(String id, String name, String password, Fridge fridge) {

--- a/src/main/java/com/example/naengtal/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/example/naengtal/domain/member/exception/MemberErrorCode.java
@@ -13,6 +13,7 @@ public enum MemberErrorCode implements ErrorCode {
     WRONG_CONFIRM_PASSWORD(HttpStatus.BAD_REQUEST, "wrong confirm password"),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "member not found"),
     CANNOT_INVITE_SELF(HttpStatus.BAD_REQUEST, "cannot invite self"),
+    ALREADY_SHARING(HttpStatus.BAD_REQUEST, "already sharing"),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/com/example/naengtal/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/example/naengtal/domain/member/exception/MemberErrorCode.java
@@ -9,9 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 
-    UNAVAILABLE_ID(HttpStatus.BAD_REQUEST, "Unavailable id"),
-    WRONG_CONFIRM_PASSWORD(HttpStatus.BAD_REQUEST, "Wrong confirm password"),
+    UNAVAILABLE_ID(HttpStatus.BAD_REQUEST, "unavailable id"),
+    WRONG_CONFIRM_PASSWORD(HttpStatus.BAD_REQUEST, "wrong confirm password"),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "member not found"),
+    CANNOT_INVITE_SELF(HttpStatus.BAD_REQUEST, "cannot invite self"),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
@@ -57,10 +57,13 @@ public class AccountService {
     }
 
     public void deleteMember(Member member) {
-        // 냉장고, 냉장고 공유 구현 후 냉장고 삭제 로직 추가해야 함
         // 외래키 제약 조건 때문에 member 먼저 삭제 후 fridge 삭제해야 함
-        int fridgeId = member.getFridge().getId();
+        Fridge fridge = member.getFridge();
+
         memberRepository.delete(member);
-        fridgeRepository.deleteById(fridgeId);
+
+        // jpa 영속성 컨텍스트 때문에 0이 아닌 1로 검사를 해줘야 함
+        if (fridge.getSharedMembers().size() == 1)
+            fridgeRepository.delete(fridge);
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
@@ -1,0 +1,39 @@
+package com.example.naengtal.domain.member.service;
+
+import com.example.naengtal.domain.alarm.entity.Alarm;
+import com.example.naengtal.domain.alarm.entity.AlarmType;
+import com.example.naengtal.domain.alarm.repository.AlarmRepository;
+import com.example.naengtal.domain.member.dao.MemberRepository;
+import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.example.naengtal.domain.member.exception.MemberErrorCode.CANNOT_INVITE_SELF;
+import static com.example.naengtal.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInvitationService {
+
+    private final MemberRepository memberRepository;
+
+    private final AlarmRepository alarmRepository;
+
+    public void invite(Member inviter, String inviteeId) {
+        Member invitee = memberRepository.findById(inviteeId)
+                .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+
+        if (inviter.getId().equals(inviteeId))
+            throw new RestApiException(CANNOT_INVITE_SELF);
+
+        Alarm alarm = Alarm.builder()
+                .member(invitee)
+                .inviter(inviter)
+                .text(inviter.getName() + "님이 냉장고 초대 요청을 보냈습니다.")
+                .type(AlarmType.INVITATION)
+                .build();
+
+        alarmRepository.save(alarm);
+    }
+}

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
@@ -3,12 +3,16 @@ package com.example.naengtal.domain.member.service;
 import com.example.naengtal.domain.alarm.entity.Alarm;
 import com.example.naengtal.domain.alarm.entity.AlarmType;
 import com.example.naengtal.domain.alarm.repository.AlarmRepository;
+import com.example.naengtal.domain.fridge.entity.Fridge;
+import com.example.naengtal.domain.fridge.repository.FridgeRepository;
 import com.example.naengtal.domain.member.dao.MemberRepository;
 import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.ALARM_NOT_FOUND;
+import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.NOT_OWN_ALARM;
 import static com.example.naengtal.domain.member.exception.MemberErrorCode.CANNOT_INVITE_SELF;
 import static com.example.naengtal.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 
@@ -20,6 +24,8 @@ public class MemberInvitationService {
 
     private final AlarmRepository alarmRepository;
 
+    private final FridgeRepository fridgeRepository;
+
     public void invite(Member inviter, String inviteeId) {
         Member invitee = memberRepository.findById(inviteeId)
                 .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
@@ -30,10 +36,27 @@ public class MemberInvitationService {
         Alarm alarm = Alarm.builder()
                 .member(invitee)
                 .inviter(inviter)
-                .text(inviter.getName() + "님이 냉장고 초대 요청을 보냈습니다.")
+                .text(inviter.getName() + " 님이 냉장고 초대 요청을 보냈습니다.")
                 .type(AlarmType.INVITATION)
                 .build();
 
         alarmRepository.save(alarm);
+    }
+
+    public void accept(Member invitee, int alarmId) {
+        Alarm alarm = alarmRepository.findById(alarmId)
+                .orElseThrow(() -> new RestApiException(ALARM_NOT_FOUND));
+
+        if (!alarm.getMember().equals(invitee))
+            throw new RestApiException(NOT_OWN_ALARM);
+
+        Fridge deleteFridge = invitee.getFridge();
+
+        invitee.setFridge(alarm.getInviter().getFridge());
+
+        if (deleteFridge.getSharedMembers().size() == 1)
+            fridgeRepository.delete(deleteFridge);
+
+        alarmRepository.delete(alarm);
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
@@ -60,7 +60,7 @@ public class MemberInvitationService {
 
         fcmService.sendByTokenList(tokenList, FcmInvitationDto.builder()
                 .title("냉장고 공유 초대 요청")
-                .body(inviter.getName() + " 님으로부터 냉장고 초대 요청을 보냈습니다.")
+                .body(inviter.getName() + " 님이 냉장고 초대 요청을 보냈습니다.")
                 .type(FcmType.INVITATION)
                 .build());
     }

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
@@ -1,17 +1,22 @@
 package com.example.naengtal.domain.member.service;
 
+import com.example.naengtal.domain.alarm.dto.FcmInvitationDto;
 import com.example.naengtal.domain.alarm.entity.Alarm;
-import com.example.naengtal.domain.alarm.entity.AlarmType;
 import com.example.naengtal.domain.alarm.repository.AlarmRepository;
 import com.example.naengtal.domain.fridge.entity.Fridge;
 import com.example.naengtal.domain.fridge.repository.FridgeRepository;
 import com.example.naengtal.domain.member.dao.MemberRepository;
 import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.common.service.FcmService;
+import com.example.naengtal.global.common.service.FcmType;
 import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+
+import java.util.List;
 
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.ALARM_NOT_FOUND;
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.NOT_OWN_ALARM;
@@ -23,11 +28,15 @@ import static com.example.naengtal.domain.member.exception.MemberErrorCode.MEMBE
 @RequiredArgsConstructor
 public class MemberInvitationService {
 
+    private final FcmService fcmService;
+
     private final MemberRepository memberRepository;
 
     private final AlarmRepository alarmRepository;
 
     private final FridgeRepository fridgeRepository;
+
+    private final RedisTemplate<String, String> redisTemplate;
 
     public void invite(Member inviter, String inviteeId) {
         Member invitee = memberRepository.findById(inviteeId)
@@ -36,14 +45,22 @@ public class MemberInvitationService {
         if (inviter.getId().equals(inviteeId))
             throw new RestApiException(CANNOT_INVITE_SELF);
 
+        // DB에 알림 저장
         Alarm alarm = Alarm.builder()
                 .member(invitee)
                 .inviter(inviter)
                 .text(inviter.getName() + " 님이 냉장고 초대 요청을 보냈습니다.")
-                .type(AlarmType.INVITATION)
                 .build();
-
         alarmRepository.save(alarm);
+
+        // 푸시 알림 보내기
+        List<String> tokenList = redisTemplate.opsForList().range(inviteeId, 0, -1);
+
+        fcmService.sendByTokenList(tokenList, FcmInvitationDto.builder()
+                .title("냉장고 공유 초대 요청")
+                .body(inviter.getName() + " 님으로부터 냉장고 초대 요청을 보냈습니다.")
+                .type(FcmType.INVITATION)
+                .build());
     }
 
     public void accept(Member invitee, int alarmId) {
@@ -53,6 +70,7 @@ public class MemberInvitationService {
         if (!alarm.getMember().equals(invitee))
             throw new RestApiException(NOT_OWN_ALARM);
 
+        // 기존 냉장고 삭제하고 초대한 사람의 냉장고 사용하기
         Fridge deleteFridge = invitee.getFridge();
 
         invitee.setFridge(alarm.getInviter().getFridge());
@@ -60,6 +78,7 @@ public class MemberInvitationService {
         if (deleteFridge.getSharedMembers().size() == 1)
             fridgeRepository.delete(deleteFridge);
 
+        // 해당 알림 삭제
         alarmRepository.delete(alarm);
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
@@ -11,12 +11,15 @@ import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.ALARM_NOT_FOUND;
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.NOT_OWN_ALARM;
 import static com.example.naengtal.domain.member.exception.MemberErrorCode.CANNOT_INVITE_SELF;
 import static com.example.naengtal.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberInvitationService {
 

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
@@ -20,8 +20,7 @@ import java.util.List;
 
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.ALARM_NOT_FOUND;
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.NOT_OWN_ALARM;
-import static com.example.naengtal.domain.member.exception.MemberErrorCode.CANNOT_INVITE_SELF;
-import static com.example.naengtal.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+import static com.example.naengtal.domain.member.exception.MemberErrorCode.*;
 
 @Service
 @Transactional
@@ -44,6 +43,9 @@ public class MemberInvitationService {
 
         if (inviter.getId().equals(inviteeId))
             throw new RestApiException(CANNOT_INVITE_SELF);
+
+        if (inviter.getFridge() == invitee.getFridge())
+            throw new RestApiException(ALREADY_SHARING);
 
         // DB에 알림 저장
         Alarm alarm = Alarm.builder()

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberSearchService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberSearchService.java
@@ -1,0 +1,27 @@
+package com.example.naengtal.domain.member.service;
+
+import com.example.naengtal.domain.member.dao.MemberRepository;
+import com.example.naengtal.domain.member.dto.MemberResponseDto;
+import com.example.naengtal.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemberSearchService {
+
+    private final MemberRepository memberRepository;
+
+    public List<MemberResponseDto> search(Member inviter, String nameOrId) {
+        List<Member> memberList = memberRepository.findByNameContainsOrIdContains(nameOrId, nameOrId);
+
+        memberList.remove(inviter); // 본인은 검색 대상에서 제외
+
+        return memberList.stream()
+                .map(member -> new MemberResponseDto(member.getName(), member.getId(), inviter.getFridge().equals(member.getFridge())))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberSearchService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberSearchService.java
@@ -24,4 +24,14 @@ public class MemberSearchService {
                 .map(member -> new MemberResponseDto(member.getName(), member.getId(), inviter.getFridge().equals(member.getFridge())))
                 .collect(Collectors.toList());
     }
+
+    public List<MemberResponseDto> searchSharedMembers(Member member) {
+        List<Member> memberList = member.getFridge().getSharedMembers();
+
+        memberList.remove(member);
+
+        return memberList.stream()
+                .map(sharedMember -> new MemberResponseDto(sharedMember.getName(), sharedMember.getId(), true))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberSearchService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberSearchService.java
@@ -6,10 +6,12 @@ import com.example.naengtal.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberSearchService {
 

--- a/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
@@ -1,8 +1,10 @@
 package com.example.naengtal.global.auth.controller;
 
+import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.global.auth.dto.SignInRequestDto;
 import com.example.naengtal.global.auth.dto.TokenDto;
 import com.example.naengtal.global.auth.service.AuthenticationService;
+import com.example.naengtal.global.common.annotation.LoggedInUser;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -23,14 +25,17 @@ public class AuthenticationApiController {
 
     @PostMapping("signin")
     private ResponseEntity<TokenDto> signIn(@Validated @RequestBody SignInRequestDto signInRequestDto) {
-        TokenDto tokenDto = authenticationService.signIn(signInRequestDto.getId(), signInRequestDto.getPassword());
+        TokenDto tokenDto = authenticationService.signIn(
+                signInRequestDto.getId(), signInRequestDto.getPassword(), signInRequestDto.getFcmToken());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(tokenDto);
     }
 
-    @PostMapping("signout")
-    private ResponseEntity<String> signOut(@Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
-        authenticationService.signOut(authorization.substring(BEARER_PREFIX.length()));
+    @PostMapping("signout/{fcm_token}")
+    private ResponseEntity<String> signOut(@Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
+                                           @Parameter(hidden = true) @LoggedInUser Member member,
+                                           @PathVariable("fcm_token") String fcmToken) {
+        authenticationService.signOut(authorization.substring(BEARER_PREFIX.length()), member.getId(), fcmToken);
         return ResponseEntity.status(HttpStatus.OK)
                 .body("signout success!");
     }

--- a/src/main/java/com/example/naengtal/global/auth/dto/SignInRequestDto.java
+++ b/src/main/java/com/example/naengtal/global/auth/dto/SignInRequestDto.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 public class SignInRequestDto {
     private String id;
     private String password;
+    private String fcmToken;
 }

--- a/src/main/java/com/example/naengtal/global/common/service/FcmService.java
+++ b/src/main/java/com/example/naengtal/global/common/service/FcmService.java
@@ -39,7 +39,7 @@ public class FcmService {
     }
 
     public void sendByTokenList(List<String> tokenList, FcmInvitationDto dto) {
-        MulticastMessage multicastMessage = makeMessages(tokenList, dto);
+        MulticastMessage multicastMessage = makeMulticastMessage(tokenList, dto);
 
         try {
             BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(multicastMessage);
@@ -60,7 +60,7 @@ public class FcmService {
 
     }
 
-    public MulticastMessage makeMessages(List<String> tokenList, FcmInvitationDto dto) {
+    public MulticastMessage makeMulticastMessage(List<String> tokenList, FcmInvitationDto dto) {
         return MulticastMessage.builder()
                 .addAllTokens(tokenList)
                 .setNotification(

--- a/src/main/java/com/example/naengtal/global/common/service/FcmService.java
+++ b/src/main/java/com/example/naengtal/global/common/service/FcmService.java
@@ -1,0 +1,75 @@
+package com.example.naengtal.global.common.service;
+
+import com.example.naengtal.domain.alarm.dto.FcmInvitationDto;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+public class FcmService {
+
+    @Value("${fcm.key.path}")
+    private String FCM_PRIVATE_KEY_PATH;
+
+
+    @PostConstruct
+    public void init() throws IOException {
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(
+                        GoogleCredentials
+                                .fromStream(new FileInputStream(FCM_PRIVATE_KEY_PATH))
+                                )
+                .build();
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(options);
+        }
+    }
+
+    public void sendByTokenList(List<String> tokenList, FcmInvitationDto dto) {
+        MulticastMessage multicastMessage = makeMessages(tokenList, dto);
+
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(multicastMessage);
+
+            if (response.getFailureCount() > 0) {
+                List<SendResponse> responses = response.getResponses();
+                List<String> failedTokens = new ArrayList<>();
+                for (int i = 0; i < responses.size(); i++) {
+                    if (!responses.get(i).isSuccessful()) {
+                        failedTokens.add(tokenList.get(i));
+                    }
+                }
+                log.error("List of tokens are not valid FCM token : " + failedTokens);
+            }
+        } catch (FirebaseMessagingException e) {
+                log.error("cannot send to memberList push message. error info : {}", e.getMessage());
+        }
+
+    }
+
+    public MulticastMessage makeMessages(List<String> tokenList, FcmInvitationDto dto) {
+        return MulticastMessage.builder()
+                .addAllTokens(tokenList)
+                .setNotification(
+                        Notification.builder()
+                                .setTitle(dto.getTitle())
+                                .setBody(dto.getBody())
+                                .build()
+                )
+                .putData("type", dto.getType().name())
+                .build();
+    }
+}

--- a/src/main/java/com/example/naengtal/global/common/service/FcmType.java
+++ b/src/main/java/com/example/naengtal/global/common/service/FcmType.java
@@ -1,0 +1,7 @@
+package com.example.naengtal.global.common.service;
+
+public enum FcmType {
+
+    INVITATION,
+    CLOSE_TO_EXPIRATION
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
 jwt:
   secret: ${JWT_SECRET_KEY}
   validate-in-seconds: 7776000
+
+fcm:
+  key:
+    path: ${FCM_KEY_PATH}

--- a/src/test/java/com/example/naengtal/global/auth/SecurityTest.java
+++ b/src/test/java/com/example/naengtal/global/auth/SecurityTest.java
@@ -73,7 +73,7 @@ public class SecurityTest {
     @Test
     @DisplayName("로그인 성공")
     void login_success() {
-        String accessToken = authenticationService.signIn("test", "test1234").getAccessToken();
+        String accessToken = authenticationService.signIn("test", "test1234", null).getAccessToken();
 
         assertThat(accessToken).isNotNull();
     }
@@ -81,13 +81,13 @@ public class SecurityTest {
     @Test
     @DisplayName("로그인 실패")
     void login_fail() {
-        assertThatThrownBy(() -> authenticationService.signIn("test", "test1233")).isInstanceOf(RestApiException.class);
+        assertThatThrownBy(() -> authenticationService.signIn("test", "test1233", null)).isInstanceOf(RestApiException.class);
     }
 
     @Test
     @DisplayName("accessToken 검증 성공")
     void access_token_validate_success() {
-        String accessToken = authenticationService.signIn("test", "test1234").getAccessToken();
+        String accessToken = authenticationService.signIn("test", "test1234", null).getAccessToken();
 
         assertThat(jwtTokenProvider.validateToken(accessToken)).isTrue();
     }
@@ -144,11 +144,11 @@ public class SecurityTest {
     @Test
     @DisplayName("로그아웃_성공")
     void signOutTest() throws Exception {
-        String accessToken = authenticationService.signIn("test", "test1234").getAccessToken();
+        String accessToken = authenticationService.signIn("test", "test1234", null).getAccessToken();
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken);
 
-        authenticationService.signOut(accessToken);
+        authenticationService.signOut(accessToken, "test",null);
 
 
         mockMvc.perform(post("/auth/signout")


### PR DESCRIPTION
## 개요
- 냉장고 초대 요청, 수락 구현
- 냉장고 초대 시 푸시알림 구현

## 작업사항
- 멤버 검색
  - `search/{name_or_id}`로 get 요청을 보내면 id나 name에 해당 문자열이 들어가는 사용자 리스트를 반환해줌.
  - `MemberResponseDto`에 넣어서 반환해주는데, id와 name, 나와 냉장고를 공유하고 있는지 여부를 알려줌.
  - 본인은 검색 대상에서 제외함.
- 냉장고 초대 요청
  - `invite/{member_id}`로 get 요청을 보내면 해당 사용자한테 초대 알림이 감.
  - 이때 FCM을 이용하여 푸시알림을 보냄.
- 냉장고 초대 수락
  - `accept/{alarm_id}`로 get 요청을 보내면 냉장고 공유가 시작됨.
  - 기존 냉장고는 삭제되고 초대한 사람의 냉장고를 사용하게 됨.
- 냉장고 공유 멤버 조회
  - `get/sharedmembers`로 get 요청을 보내면 냉장고를 공유하고 있는 멤버들의 리스트가 `List<MemberResponseDto>` 형태로 반환됨
- FCM 푸시 알림
  - fcm 푸시 알림을 날리기 위해 비공개 키 파일 필요(카톡으로 줄게~~) 비공개 키 파일을 다운 받고 파일의 경로를 FCM_KEY_PATH 환경변수로 등록해야 함.
  - 푸시알림을 구현하기 위해 로그인 시 fcm token을 받아오도록 수정함.
  - 로그인 시 받아온 fcm token은 여러 기기에서 로그인하는 경우를 대비하여 레디스에 리스트 형태로 저장되고, 로그아웃 시 삭제됨.
  - 아래 형태로 메시지가 전송되는데, data 필드의 type은 어떤 푸시알림인지 구분하는 용도. (프론트에서 필요 없다하면 안 쓸 수도 있음)
  - 참고로 푸시알림과 관련된 로직은 global.common.service.FcmService에 작성함.
```
{
  "message":{
    "token":"bk3RNwTe3H0:CI2k_HHwgIpoDKCIZvvDMExUdFQ3P1...",
    "notification":{
      "title":"냉장고 공유 초대 요청",
      "body":"어쩌구저쩌구 님이 냉장고 초대 요청을 보냈습니다."
    },
    "data" : {
      "type" : "INVITATION"
    }
  }
}
```
## 변경로직
- fcm token 받아오느라 로그인, 로그아웃, SecurityTest가 수정됨. (기존 로직은 바뀌는 거 없고 추가만 함)
- Alarm 테이블에서 type 컬럼 삭제하고, inviter 외래키 추가함.
- member 클래스와 Alarm 클래스 간에 양방향 연관관계 매핑함. 회원 탈퇴 시 본인과 관련된 알람 삭제될 수 있도록 orphanRemoval = true 옵션 줌. 
- member 클래스와 Fridge 클래스 간에 양방향 연관관계 매핑함.
- 회원 탈퇴 시 본인 제외 냉장고 공유 인원이 0명인 경우 냉장고 삭제되도록 로직 변경함.