### PR TITLE
개인정보 조회, 닉네임 변경, 냉장고 나가기 구현

### DIFF
--- a/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
@@ -1,10 +1,11 @@
 package com.example.naengtal.domain.member.controller;
 
+import com.example.naengtal.domain.member.dto.MemberInfo;
 import com.example.naengtal.domain.member.dto.SignUpRequestDto;
-import com.example.naengtal.domain.member.dto.SignUpResponseDto;
 import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.domain.member.service.AccountService;
 import com.example.naengtal.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,18 +20,33 @@ public class AccountApiController {
     private final AccountService accountService;
 
     @PostMapping("signup")
-    public ResponseEntity<SignUpResponseDto> signUp(@Validated @RequestBody SignUpRequestDto signUpRequestDto) {
-        SignUpResponseDto dto = accountService.saveMember(signUpRequestDto);
+    public ResponseEntity<MemberInfo> signUp(@Validated @RequestBody SignUpRequestDto signUpRequestDto) {
+        MemberInfo dto = accountService.saveMember(signUpRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(dto);
     }
 
     @DeleteMapping("delete")
-    public ResponseEntity<String> withdrawal(@LoggedInUser Member member) {
+    public ResponseEntity<String> withdrawal(@Parameter(hidden = true) @LoggedInUser Member member) {
         accountService.deleteMember(member);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body("success");
+    }
+
+    @PostMapping("edit")
+    public ResponseEntity<String> editName(@Parameter(hidden = true) @LoggedInUser Member member,
+                                           @PathVariable(value = "name") String name) {
+        accountService.editName(member, name);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("success");
+    }
+
+    @GetMapping("info")
+    public ResponseEntity<MemberInfo> getInfo(@Parameter(hidden = true) @LoggedInUser Member member) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(accountService.getInfo(member));
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/AccountApiController.java
@@ -37,7 +37,7 @@ public class AccountApiController {
 
     @PostMapping("edit")
     public ResponseEntity<String> editName(@Parameter(hidden = true) @LoggedInUser Member member,
-                                           @PathVariable(value = "name") String name) {
+                                           @RequestParam(value = "name") String name) {
         accountService.editName(member, name);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -28,7 +29,6 @@ public class FridgeShareApiController {
                                                           @PathVariable("name_or_id") String nameOrId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberSearchService.search(inviter, nameOrId));
-
     }
 
     @GetMapping("get/sharedmembers")
@@ -50,6 +50,14 @@ public class FridgeShareApiController {
     public ResponseEntity<String> accept(@Parameter(hidden = true) @LoggedInUser Member invitee,
                                          @PathVariable("alarm_id") int alarmId) {
         memberInvitationService.accept(invitee, alarmId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("success");
+    }
+
+    @PostMapping("leave")
+    public ResponseEntity<String> leaveFridge(@Parameter(hidden = true) @LoggedInUser Member member){
+        memberInvitationService.leaveFridge(member);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body("success");

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
@@ -55,8 +55,8 @@ public class FridgeShareApiController {
                 .body("success");
     }
 
-    @PostMapping("leave")
-    public ResponseEntity<String> leaveFridge(@Parameter(hidden = true) @LoggedInUser Member member){
+    @PostMapping("leave/fridge")
+    public ResponseEntity<String> leaveFridge(@Parameter(hidden = true) @LoggedInUser Member member) {
         memberInvitationService.leaveFridge(member);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/example/naengtal/domain/member/dto/MemberInfo.java
+++ b/src/main/java/com/example/naengtal/domain/member/dto/MemberInfo.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 @Builder
 @AllArgsConstructor
-public class SignUpResponseDto {
+public class MemberInfo {
 
     private String id;
 

--- a/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
@@ -3,8 +3,8 @@ package com.example.naengtal.domain.member.service;
 import com.example.naengtal.domain.fridge.entity.Fridge;
 import com.example.naengtal.domain.fridge.repository.FridgeRepository;
 import com.example.naengtal.domain.member.dao.MemberRepository;
+import com.example.naengtal.domain.member.dto.MemberInfo;
 import com.example.naengtal.domain.member.dto.SignUpRequestDto;
-import com.example.naengtal.domain.member.dto.SignUpResponseDto;
 import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class AccountService {
 
     private final PasswordEncoder passwordEncoder;
 
-    public SignUpResponseDto saveMember(SignUpRequestDto signUpRequestDto) {
+    public MemberInfo saveMember(SignUpRequestDto signUpRequestDto) {
         // id 중복 검사
         memberRepository.findById(signUpRequestDto.getId()).ifPresent(a -> {
             throw new RestApiException(UNAVAILABLE_ID);
@@ -49,11 +49,7 @@ public class AccountService {
                 .fridge(fridge)
                 .build());
 
-        return SignUpResponseDto.builder()
-                .name(member.getName())
-                .id(member.getId())
-                .fridgeId(fridge.getId())
-                .build();
+        return getInfo(member);
     }
 
     public void deleteMember(Member member) {
@@ -65,5 +61,17 @@ public class AccountService {
         // jpa 영속성 컨텍스트 때문에 0이 아닌 1로 검사를 해줘야 함
         if (fridge.getSharedMembers().size() == 1)
             fridgeRepository.delete(fridge);
+    }
+
+    public void editName(Member member, String name) {
+        member.setName(name);
+    }
+
+    public MemberInfo getInfo(Member member) {
+        return MemberInfo.builder()
+                .name(member.getName())
+                .id(member.getId())
+                .fridgeId(member.getFridge().getId())
+                .build();
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/MemberInvitationService.java
@@ -15,7 +15,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-
 import java.util.List;
 
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.ALARM_NOT_FOUND;
@@ -82,5 +81,19 @@ public class MemberInvitationService {
 
         // 해당 알림 삭제
         alarmRepository.delete(alarm);
+    }
+
+    public void leaveFridge(Member member) {
+        Fridge preFridge = member.getFridge();
+
+        // 냉장고의 마지막 남은 사용자일 때 -> 기존 냉장고 삭제
+        if (preFridge.getSharedMembers().size() == 1) {
+            fridgeRepository.delete(preFridge);
+        }
+
+        Fridge newFridge = new Fridge();
+        fridgeRepository.save(newFridge);
+
+        member.setFridge(newFridge);
     }
 }

--- a/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
@@ -27,6 +27,7 @@ public class AuthenticationApiController {
     private ResponseEntity<TokenDto> signIn(@Validated @RequestBody SignInRequestDto signInRequestDto) {
         TokenDto tokenDto = authenticationService.signIn(
                 signInRequestDto.getId(), signInRequestDto.getPassword(), signInRequestDto.getFcmToken());
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(tokenDto);
     }

--- a/src/test/java/com/example/naengtal/domain/member/service/MemberInvitationServiceTest.java
+++ b/src/test/java/com/example/naengtal/domain/member/service/MemberInvitationServiceTest.java
@@ -1,0 +1,75 @@
+package com.example.naengtal.domain.member.service;
+
+import com.example.naengtal.domain.alarm.repository.AlarmRepository;
+import com.example.naengtal.domain.fridge.entity.Fridge;
+import com.example.naengtal.domain.fridge.repository.FridgeRepository;
+import com.example.naengtal.domain.member.dao.MemberRepository;
+import com.example.naengtal.domain.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class MemberInvitationServiceTest {
+
+    @InjectMocks
+    private MemberInvitationService memberInvitationService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FridgeRepository fridgeRepository;
+
+    @Mock
+    private AlarmRepository alarmRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Test
+    @DisplayName("본인만 남았을 때 냉장고 나가기")
+    void leave_fridge_when_alone() {
+        Fridge fridge = new Fridge(1);
+        Member member = Member.builder()
+                .name("test")
+                .id("test")
+                .password("encodedPassword")
+                .fridge(fridge)
+                .build();
+
+        memberInvitationService.leaveFridge(member);
+
+        assertThat(member.getFridge().getId()).isNotEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("여러명 있을 때 냉장고 나가기")
+    void leave_fridge() {
+        Fridge fridge = new Fridge(1);
+        Member member1 = Member.builder()
+                .name("test1")
+                .id("test1")
+                .password("encodedPassword")
+                .fridge(fridge)
+                .build();
+        Member member2 = Member.builder()
+                .name("test2")
+                .id("test2")
+                .password("encodedPassword")
+                .fridge(fridge)
+                .build();
+
+        memberInvitationService.leaveFridge(member1);
+
+        assertThat(member1.getFridge().getId()).isNotEqualTo(1);
+        assertThat(member2.getFridge().getId()).isEqualTo(1);
+    }
+
+}


### PR DESCRIPTION
## 개요
- 본인 계정 정보(아이디, 비밀번호, 냉장고 아이디) 조회
- 공유 냉장고 나가기 구현
- 닉네임 변경 기능 구현

## 작업사항
- '/account/edit?name=바꿀이름'으로 요청 시 닉네임 변경
- '/account/info'로 Get 요청 시 본인 아이디, 닉네임, 냉장고 아이디를 리턴받을 수 있게 함
- '/leave/fridge'로 요청 시 본인이 속하고 있는 냉장고를 나간 후 새로운 냉장고를 생성하여 연결하는데, 본인이 마지막 멤버일 때는 기존 냉장고는 삭제된다.

## 변경로직
- SignUpResponseDto 클래스 이름을 MemberInfo로 변경(계정 정보 리턴할때도 똑같은 정보를 리턴하여 같이 사용할 수 있도록 이름 변경)
