### PR TITLE
에러코드 refactor

### DIFF
--- a/src/main/java/com/example/naengtal/domain/ingredient/exception/IngredientErrorCode.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/exception/IngredientErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum IngredientErrorCode implements ErrorCode {
 
-    INGREDIENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "ingredient not found");
+    INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ingredient not found");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/naengtal/global/common/service/S3Uploader.java
+++ b/src/main/java/com/example/naengtal/global/common/service/S3Uploader.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.UUID;
 
 import static com.example.naengtal.global.error.CommonErrorCode.IMAGE_UPLOAD_FAIL;
+import static com.example.naengtal.global.error.CommonErrorCode.ONLY_IMAGE_ALLOWED;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,6 +31,7 @@ public class S3Uploader {
 
     // MultipartFile 을 전달받아 File 로 전환한 후 S3에 업로드
     public String upload(MultipartFile multipartFile) {
+        validateContentType(multipartFile);
         String s3FileName = createFileName();
 
         try {
@@ -57,5 +59,14 @@ public class S3Uploader {
     // 파일 이름 생성(중복 피하기)
     private String createFileName() {
         return UUID.randomUUID().toString();
+    }
+
+    // 파일 확장자 검사 (jpg, png 만 가능)
+    private void validateContentType(MultipartFile multipartFile) {
+        String contentType = multipartFile.getContentType();
+        System.out.println(contentType);
+        if (contentType == null || (!contentType.equals("image/jpeg") && !contentType.equals("image/png"))) {
+            throw new RestApiException(ONLY_IMAGE_ALLOWED);
+        }
     }
 }

--- a/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
+++ b/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
@@ -12,7 +12,8 @@ public enum CommonErrorCode implements ErrorCode {
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "resource not exists"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal server error"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden"),
-    IMAGE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "image upload fail");
+    IMAGE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "image upload fail"),
+    ONLY_IMAGE_ALLOWED(HttpStatus.BAD_REQUEST, "only image are allowed for upload");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
+++ b/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
@@ -12,7 +12,7 @@ public enum CommonErrorCode implements ErrorCode {
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "resource not exists"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal server error"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden"),
-    IMAGE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "image upload fail"),
+    IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "image upload fail"),
     ONLY_IMAGE_ALLOWED(HttpStatus.BAD_REQUEST, "only image are allowed for upload");
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 개요
- 에러코드 리팩토링

## 작업사항
- 파일 업로드 시 이미지만 업로드 가능하게 구현

## 변경로직
- AWS S3 파일 업로드 실패 시 에러코드 400 -> 500으로 변경
- 재료 존재하지 않을 시 에러코드 400 -> 404f로 변경
