### PR TITLE
재료 카테고리 검색 구현

### DIFF
--- a/src/main/java/com/example/naengtal/domain/ingredient/controller/IngredientApiController.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/controller/IngredientApiController.java
@@ -49,4 +49,10 @@ public class IngredientApiController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body("success");
     }
+
+    @PostMapping("search")
+    public ResponseEntity<List<String>> searchCategory(@RequestParam(name = "category") String category) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ingredientService.search(category));
+    }
 }

--- a/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientCategoryRepository.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientCategoryRepository.java
@@ -1,0 +1,16 @@
+package com.example.naengtal.domain.ingredient.dao;
+
+import com.example.naengtal.domain.ingredient.entity.IngredientCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface IngredientCategoryRepository extends JpaRepository<IngredientCategory, Integer> {
+
+    @Query("select distinct c.category from IngredientCategory c where c.category like %:category% order by c.category")
+    List<String> findByCategoryContainsOrderByCategory(@Param("category") String category);
+}

--- a/src/main/java/com/example/naengtal/domain/ingredient/entity/IngredientCategory.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/entity/IngredientCategory.java
@@ -1,0 +1,26 @@
+package com.example.naengtal.domain.ingredient.entity;
+
+import lombok.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "ingredient_category")
+@Getter
+@Setter
+@NoArgsConstructor
+public class IngredientCategory {
+
+    @Id
+    @Column(name = "category_id")
+    int category_id;
+
+    @Column(name = "recipe_code")
+    int recipe_code;
+
+    @Column(name = "category")
+    String category;
+}

--- a/src/main/java/com/example/naengtal/domain/ingredient/entity/IngredientCategory.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/entity/IngredientCategory.java
@@ -16,10 +16,10 @@ public class IngredientCategory {
 
     @Id
     @Column(name = "category_id")
-    int category_id;
+    int categoryId;
 
     @Column(name = "recipe_code")
-    int recipe_code;
+    int recipeCode;
 
     @Column(name = "category")
     String category;

--- a/src/main/java/com/example/naengtal/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/service/IngredientService.java
@@ -5,6 +5,7 @@ import com.example.naengtal.domain.ingredient.dao.IngredientRepository;
 import com.example.naengtal.domain.ingredient.dto.IngredientRequestDto;
 import com.example.naengtal.domain.ingredient.dto.IngredientResponseDto;
 import com.example.naengtal.domain.ingredient.entity.Ingredient;
+import com.example.naengtal.domain.ingredient.dao.IngredientCategoryRepository;
 import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.global.common.service.S3Uploader;
 import com.example.naengtal.global.error.RestApiException;
@@ -27,6 +28,7 @@ public class IngredientService {
 
     private final IngredientRepository ingredientRepository;
     private final S3Uploader s3Uploader;
+    private final IngredientCategoryRepository ingredientCategoryRepository;
 
     public void save(Member member, MultipartFile image, IngredientRequestDto ingredientRequestDto) {
         // 이미지 업로드
@@ -74,5 +76,9 @@ public class IngredientService {
         s3Uploader.deleteFile(ingredient.getImage());
 
         ingredientRepository.delete(ingredient);
+    }
+
+    public List<String> search(String category) {
+        return ingredientCategoryRepository.findByCategoryContainsOrderByCategory(category);
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/dao/IngredientCategoryRepository.java
+++ b/src/main/java/com/example/naengtal/domain/member/dao/IngredientCategoryRepository.java
@@ -1,0 +1,9 @@
+package com.example.naengtal.domain.member.dao;
+
+import com.example.naengtal.domain.ingredient.entity.IngredientCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IngredientCategoryRepository extends JpaRepository<IngredientCategory, Integer> {
+}

--- a/src/main/java/com/example/naengtal/domain/member/dao/IngredientCategoryRepository.java
+++ b/src/main/java/com/example/naengtal/domain/member/dao/IngredientCategoryRepository.java
@@ -1,9 +1,0 @@
-package com.example.naengtal.domain.member.dao;
-
-import com.example.naengtal.domain.ingredient.entity.IngredientCategory;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface IngredientCategoryRepository extends JpaRepository<IngredientCategory, Integer> {
-}


### PR DESCRIPTION
## 개요
재료 등록 시 카테고리 검색 구현

## 작업사항
- 검색어로 들어온 문자열이 포함된 카테고리 리스트를 반환한다.
- ex) /ingredient/search/category=콩  ---> ["콩", "콩가루", "콩나물"]
