### PR TITLE
레시피 추천 구현

### DIFF
--- a/src/main/java/com/example/naengtal/domain/alarm/dto/AlarmResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/dto/AlarmResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.naengtal.domain.alarm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AlarmResponseDto {
+
+    private int alarmId;
+
+    private String content;
+}

--- a/src/main/java/com/example/naengtal/domain/ingredient/controller/IngredientApiController.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/controller/IngredientApiController.java
@@ -50,7 +50,7 @@ public class IngredientApiController {
                 .body("success");
     }
 
-    @PostMapping("search")
+    @GetMapping("search")
     public ResponseEntity<List<String>> searchCategory(@RequestParam(name = "category") String category) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ingredientService.search(category));

--- a/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientCategoryRepository.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientCategoryRepository.java
@@ -13,4 +13,7 @@ public interface IngredientCategoryRepository extends JpaRepository<IngredientCa
 
     @Query("select distinct c.category from IngredientCategory c where c.category like %:category% order by c.category")
     List<String> findByCategoryContainsOrderByCategory(@Param("category") String category);
+
+    @Query("select c.recipeCode from IngredientCategory c where c.category like :category")
+    List<Integer> findRecipeCodeByCategory(@Param("category") String category);
 }

--- a/src/main/java/com/example/naengtal/domain/ingredient/entity/IngredientCategory.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/entity/IngredientCategory.java
@@ -16,11 +16,11 @@ public class IngredientCategory {
 
     @Id
     @Column(name = "category_id")
-    int categoryId;
+    private int categoryId;
 
     @Column(name = "recipe_code")
-    int recipeCode;
+    private int recipeCode;
 
     @Column(name = "category")
-    String category;
+    private String category;
 }

--- a/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
+++ b/src/main/java/com/example/naengtal/domain/member/controller/FridgeShareApiController.java
@@ -1,5 +1,6 @@
 package com.example.naengtal.domain.member.controller;
 
+import com.example.naengtal.domain.alarm.dto.AlarmResponseDto;
 import com.example.naengtal.domain.member.dto.MemberResponseDto;
 import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.domain.member.service.MemberInvitationService;
@@ -9,10 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -61,5 +59,20 @@ public class FridgeShareApiController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body("success");
+    }
+
+    @DeleteMapping("reject/{alarm_id}")
+    public ResponseEntity<String> reject(@Parameter(hidden = true) @LoggedInUser Member invitee,
+                                         @PathVariable("alarm_id") int alarmId) {
+        memberInvitationService.reject(invitee, alarmId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("success");
+    }
+
+    @GetMapping("get/alarms")
+    public ResponseEntity<List<AlarmResponseDto>> getAlarmList(@Parameter(hidden = true) @LoggedInUser Member member) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(memberInvitationService.getAlarmList(member));
     }
 }

--- a/src/main/java/com/example/naengtal/domain/member/entity/Member.java
+++ b/src/main/java/com/example/naengtal/domain/member/entity/Member.java
@@ -33,7 +33,7 @@ public class Member {
     private Fridge fridge;
 
     @OneToMany(mappedBy = "member", orphanRemoval = true)
-    private List<Alarm> alarm = new ArrayList<>();
+    private List<Alarm> alarms = new ArrayList<>();
 
     @OneToMany(mappedBy = "inviter", orphanRemoval = true)
     private List<Alarm> relatedAlarms = new ArrayList<>();

--- a/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
@@ -1,14 +1,12 @@
 package com.example.naengtal.domain.recipe.controller;
 
 import com.example.naengtal.domain.recipe.dto.RecipeInfoResponseDto;
+import com.example.naengtal.domain.recipe.dto.SpecificRecipeResponseDto;
 import com.example.naengtal.domain.recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,9 +17,15 @@ public class RecipeRecommandationApiController {
 
     private final RecipeService recipeService;
 
-    @GetMapping("")
+    @GetMapping("list")
     public ResponseEntity<List<RecipeInfoResponseDto>> getRecipeInfoList(@RequestParam("ingredientid") int ingredientId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(recipeService.getRecipeInfoList(ingredientId));
+    }
+
+    @GetMapping("specific/{recipe_code}")
+    public ResponseEntity<SpecificRecipeResponseDto> getSpecificRecipe(@PathVariable("recipe_code") int recipeCode) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(recipeService.getSpecificRecipe(recipeCode));
     }
 }

--- a/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
@@ -17,8 +17,8 @@ public class RecipeRecommandationApiController {
 
     private final RecipeService recipeService;
 
-    @GetMapping("list")
-    public ResponseEntity<List<RecipeInfoResponseDto>> getRecipeInfoList(@RequestParam("ingredientid") int ingredientId) {
+    @GetMapping("list/{ingredient_id}")
+    public ResponseEntity<List<RecipeInfoResponseDto>> getRecipeInfoList(@PathVariable("ingredient_id") int ingredientId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(recipeService.getRecipeInfoList(ingredientId));
     }

--- a/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
@@ -1,0 +1,27 @@
+package com.example.naengtal.domain.recipe.controller;
+
+import com.example.naengtal.domain.recipe.dto.RecipeInfoResponseDto;
+import com.example.naengtal.domain.recipe.service.RecipeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("recipe/")
+public class RecipeRecommandationApiController {
+
+    private final RecipeService recipeService;
+
+    @GetMapping("")
+    public ResponseEntity<List<RecipeInfoResponseDto>> getRecipeInfoList(@RequestParam("ingredientid") int ingredientId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(recipeService.getRecipeInfoList(ingredientId));
+    }
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeInfoRepository.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeInfoRepository.java
@@ -1,0 +1,9 @@
+package com.example.naengtal.domain.recipe.dao;
+
+import com.example.naengtal.domain.recipe.entity.RecipeInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeInfoRepository extends JpaRepository<RecipeInfo, Integer> {
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeIngredientRepository.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeIngredientRepository.java
@@ -4,6 +4,10 @@ import com.example.naengtal.domain.recipe.entity.RecipeIngredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredient, Integer> {
+
+    List<RecipeIngredient> findByRecipeCodeOrderByIngredientNumber(int recipeCode);
 }

--- a/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeIngredientRepository.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeIngredientRepository.java
@@ -1,0 +1,9 @@
+package com.example.naengtal.domain.recipe.dao;
+
+import com.example.naengtal.domain.recipe.entity.RecipeIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredient, Integer> {
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeProcessRepository.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeProcessRepository.java
@@ -4,6 +4,10 @@ import com.example.naengtal.domain.recipe.entity.RecipeProcess;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RecipeProcessRepository extends JpaRepository<RecipeProcess, Integer> {
+
+    List<RecipeProcess> findByRecipeCodeOrderByProcessNumber(int recipeCode);
 }

--- a/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeProcessRepository.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dao/RecipeProcessRepository.java
@@ -1,0 +1,9 @@
+package com.example.naengtal.domain.recipe.dao;
+
+import com.example.naengtal.domain.recipe.entity.RecipeProcess;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeProcessRepository extends JpaRepository<RecipeProcess, Integer> {
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeInfoResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeInfoResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.naengtal.domain.recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class RecipeInfoResponseDto {
+
+    private int recipeCode;
+
+    private String recipeName;
+
+    private String summary;
+
+    private String image;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeIngredientResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeIngredientResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.naengtal.domain.recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecipeIngredientResponseDto {
+
+    private String name;
+
+    private String amount;
+
+    private String type;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeProcessResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeProcessResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.naengtal.domain.recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecipeProcessResponseDto {
+
+    private String description;
+
+    private String image;
+
+    private String tip;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/dto/SpecificRecipeResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dto/SpecificRecipeResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.naengtal.domain.recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SpecificRecipeResponseDto {
+
+    private String name;
+
+    private String summary;
+
+    private String countryType;
+
+    private String type;
+
+    private String time;
+
+    private String calories;
+
+    private String amount;
+
+    private String difficulty;
+
+    private List<RecipeIngredientResponseDto> ingredient;
+
+    private List<RecipeProcessResponseDto> process;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeInfo.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeInfo.java
@@ -1,0 +1,49 @@
+package com.example.naengtal.domain.recipe.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "recipe_info")
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecipeInfo {
+
+    @Id
+    @Column(name = "recipe_code")
+    private int recipeCode;
+
+    @Column(name = "recipe_name")
+    private String recipeName;
+
+    @Column(name = "summary")
+    private String summary;
+
+    @Column(name = "country_type")
+    private String countryType;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "time")
+    private String time;
+
+    @Column(name = "calories")
+    private String calories;
+
+    @Column(name = "recipe_amount")
+    private String recipeAmount;
+
+    @Column(name = "difficulty")
+    private String difficulty;
+
+    @Column(name = "image")
+    private String image;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeInfo.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeInfo.java
@@ -1,5 +1,6 @@
 package com.example.naengtal.domain.recipe.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,6 +15,7 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class RecipeInfo {
 
     @Id

--- a/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeIngredient.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeIngredient.java
@@ -1,0 +1,37 @@
+package com.example.naengtal.domain.recipe.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "recipe_ingredient")
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecipeIngredient {
+
+    @Id
+    @Column(name = "ingredient_id")
+    private int ingredientId;
+
+    @Column(name = "recipe_code")
+    private int recipeCode;
+
+    @Column(name = "ingredient_number")
+    private int ingredientNumber;
+
+    @Column(name = "ingredient_name")
+    private String ingredientName;
+
+    @Column(name = "ingredient_amount")
+    private String ingredientAmount;
+
+    @Column(name = "ingredient_type")
+    private String ingredientType;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeIngredient.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeIngredient.java
@@ -1,5 +1,6 @@
 package com.example.naengtal.domain.recipe.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,6 +15,7 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class RecipeIngredient {
 
     @Id

--- a/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeProcess.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeProcess.java
@@ -1,0 +1,37 @@
+package com.example.naengtal.domain.recipe.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "recipe_process")
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecipeProcess {
+
+    @Id
+    @Column(name = "process_id")
+    private int processId;
+
+    @Column(name = "recipe_code")
+    private int recipeCode;
+
+    @Column(name = "process_number")
+    private int processNumber;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "process_image")
+    private String processImage;
+
+    @Column(name = "tip")
+    private String tip;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeProcess.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/entity/RecipeProcess.java
@@ -1,5 +1,6 @@
 package com.example.naengtal.domain.recipe.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,6 +15,7 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class RecipeProcess {
 
     @Id

--- a/src/main/java/com/example/naengtal/domain/recipe/exception/RecipeErrorCode.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/exception/RecipeErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.naengtal.domain.recipe.exception;
+
+import com.example.naengtal.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RecipeErrorCode implements ErrorCode {
+
+    RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "recipe not found"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
@@ -1,0 +1,58 @@
+package com.example.naengtal.domain.recipe.service;
+
+import com.example.naengtal.domain.ingredient.dao.IngredientCategoryRepository;
+import com.example.naengtal.domain.ingredient.dao.IngredientRepository;
+import com.example.naengtal.domain.ingredient.entity.Ingredient;
+import com.example.naengtal.domain.ingredient.entity.IngredientCategory;
+import com.example.naengtal.domain.recipe.dao.RecipeInfoRepository;
+import com.example.naengtal.domain.recipe.dao.RecipeIngredientRepository;
+import com.example.naengtal.domain.recipe.dao.RecipeProcessRepository;
+import com.example.naengtal.domain.recipe.dto.RecipeInfoResponseDto;
+import com.example.naengtal.domain.recipe.entity.RecipeInfo;
+import com.example.naengtal.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.naengtal.domain.ingredient.exception.IngredientErrorCode.INGREDIENT_NOT_FOUND;
+import static com.example.naengtal.domain.recipe.exception.RecipeErrorCode.RECIPE_NOT_FOUND;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecipeService {
+
+    private final RecipeInfoRepository recipeInfoRepository;
+
+    private final RecipeIngredientRepository recipeIngredientRepository;
+
+    private final RecipeProcessRepository recipeProcessRepository;
+
+    private final IngredientRepository ingredientRepository;
+
+    private final IngredientCategoryRepository ingredientCategoryRepository;
+
+    public List<RecipeInfoResponseDto> getRecipeInfoList(int ingredientId) {
+        Ingredient ingredient = ingredientRepository.findById(ingredientId)
+                .orElseThrow(() -> new RestApiException(INGREDIENT_NOT_FOUND));
+
+        String category = ingredient.getCategory();
+        List<Integer> recipeCodeList = ingredientCategoryRepository.findRecipeCodeByCategory(category);
+
+        return recipeCodeList.stream()
+                .map(recipeCode -> {
+                    RecipeInfo recipeInfo = recipeInfoRepository.findById(recipeCode)
+                            .orElseThrow(() -> new RestApiException(RECIPE_NOT_FOUND));
+
+                    return RecipeInfoResponseDto.builder()
+                            .recipeCode(recipeCode)
+                            .recipeName(recipeInfo.getRecipeName())
+                            .summary(recipeInfo.getSummary())
+                            .image(recipeInfo.getImage())
+                            .build();
+                }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
@@ -61,7 +61,7 @@ public class RecipeService {
     }
 
     public SpecificRecipeResponseDto getSpecificRecipe(int recipeCode) {
-        // get info, ingredinet, process from repository
+        // get info, ingredient, process from repository
         RecipeInfo info = recipeInfoRepository.findById(recipeCode)
                 .orElseThrow(() -> new RestApiException(RECIPE_NOT_FOUND));
 

--- a/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
@@ -7,7 +7,12 @@ import com.example.naengtal.domain.recipe.dao.RecipeInfoRepository;
 import com.example.naengtal.domain.recipe.dao.RecipeIngredientRepository;
 import com.example.naengtal.domain.recipe.dao.RecipeProcessRepository;
 import com.example.naengtal.domain.recipe.dto.RecipeInfoResponseDto;
+import com.example.naengtal.domain.recipe.dto.RecipeIngredientResponseDto;
+import com.example.naengtal.domain.recipe.dto.RecipeProcessResponseDto;
+import com.example.naengtal.domain.recipe.dto.SpecificRecipeResponseDto;
 import com.example.naengtal.domain.recipe.entity.RecipeInfo;
+import com.example.naengtal.domain.recipe.entity.RecipeIngredient;
+import com.example.naengtal.domain.recipe.entity.RecipeProcess;
 import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -53,5 +58,45 @@ public class RecipeService {
                             .image(recipeInfo.getImage())
                             .build();
                 }).collect(Collectors.toList());
+    }
+
+    public SpecificRecipeResponseDto getSpecificRecipe(int recipeCode) {
+        // get info, ingredinet, process from repository
+        RecipeInfo info = recipeInfoRepository.findById(recipeCode)
+                .orElseThrow(() -> new RestApiException(RECIPE_NOT_FOUND));
+
+        List<RecipeIngredient> ingredientList = recipeIngredientRepository.findByRecipeCodeOrderByIngredientNumber(recipeCode);
+
+        List<RecipeProcess> processList = recipeProcessRepository.findByRecipeCodeOrderByProcessNumber(recipeCode);
+
+        // entity to dto
+        List<RecipeIngredientResponseDto> ingredientDtoList = ingredientList.stream()
+                .map(ingredient -> RecipeIngredientResponseDto.builder()
+                        .name(ingredient.getIngredientName())
+                        .amount(ingredient.getIngredientAmount())
+                        .type(ingredient.getIngredientType())
+                        .build())
+                .collect(Collectors.toList());
+
+        List<RecipeProcessResponseDto> processDtoList = processList.stream()
+                .map(process -> RecipeProcessResponseDto.builder()
+                        .description(process.getDescription())
+                        .image(process.getProcessImage())
+                        .tip(process.getTip())
+                        .build())
+                .collect(Collectors.toList());
+
+        return SpecificRecipeResponseDto.builder()
+                .name(info.getRecipeName())
+                .summary(info.getSummary())
+                .countryType(info.getCountryType())
+                .type(info.getType())
+                .time(info.getTime())
+                .calories(info.getCalories())
+                .amount(info.getRecipeAmount())
+                .difficulty(info.getDifficulty())
+                .ingredient(ingredientDtoList)
+                .process(processDtoList)
+                .build();
     }
 }

--- a/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/service/RecipeService.java
@@ -3,7 +3,6 @@ package com.example.naengtal.domain.recipe.service;
 import com.example.naengtal.domain.ingredient.dao.IngredientCategoryRepository;
 import com.example.naengtal.domain.ingredient.dao.IngredientRepository;
 import com.example.naengtal.domain.ingredient.entity.Ingredient;
-import com.example.naengtal.domain.ingredient.entity.IngredientCategory;
 import com.example.naengtal.domain.recipe.dao.RecipeInfoRepository;
 import com.example.naengtal.domain.recipe.dao.RecipeIngredientRepository;
 import com.example.naengtal.domain.recipe.dao.RecipeProcessRepository;

--- a/src/test/java/com/example/naengtal/domain/recipe/service/RecipeServiceTest.java
+++ b/src/test/java/com/example/naengtal/domain/recipe/service/RecipeServiceTest.java
@@ -1,0 +1,185 @@
+package com.example.naengtal.domain.recipe.service;
+
+import com.example.naengtal.domain.ingredient.dao.IngredientCategoryRepository;
+import com.example.naengtal.domain.ingredient.dao.IngredientRepository;
+import com.example.naengtal.domain.ingredient.entity.Ingredient;
+import com.example.naengtal.domain.recipe.dao.RecipeInfoRepository;
+import com.example.naengtal.domain.recipe.dao.RecipeIngredientRepository;
+import com.example.naengtal.domain.recipe.dao.RecipeProcessRepository;
+import com.example.naengtal.domain.recipe.dto.RecipeInfoResponseDto;
+import com.example.naengtal.domain.recipe.dto.SpecificRecipeResponseDto;
+import com.example.naengtal.domain.recipe.entity.RecipeInfo;
+import com.example.naengtal.domain.recipe.entity.RecipeIngredient;
+import com.example.naengtal.domain.recipe.entity.RecipeProcess;
+import com.example.naengtal.global.error.RestApiException;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.naengtal.domain.ingredient.exception.IngredientErrorCode.INGREDIENT_NOT_FOUND;
+import static com.example.naengtal.domain.recipe.exception.RecipeErrorCode.RECIPE_NOT_FOUND;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RecipeServiceTest {
+
+    @InjectMocks
+    private RecipeService recipeService;
+
+    @Mock
+    private RecipeInfoRepository recipeInfoRepository;
+
+    @Mock
+    private RecipeIngredientRepository recipeIngredientRepository;
+
+    @Mock
+    private RecipeProcessRepository recipeProcessRepository;
+
+    @Mock
+    private IngredientRepository ingredientRepository;
+
+    @Mock
+    private IngredientCategoryRepository ingredientCategoryRepository;
+
+    private static RecipeInfo info;
+
+    private static List<RecipeIngredient> ingredientList;
+
+    private static List<RecipeProcess> processList;
+
+    @BeforeAll
+    static void before() {
+        info = new RecipeInfo(1, "참치김치찌개", "간단하고 맛있는 참치김치찌개", "한식",
+                "찌개", "20분", "0Kcal", "2인분", "초보환영", "imagelink");
+
+        ingredientList = Arrays.asList(new RecipeIngredient(1, 1, 1, "참치", "1캔", "주재료"),
+                new RecipeIngredient(2, 1, 2, "김치", "두 주먹", "주재료"));
+
+        processList = Arrays.asList(new RecipeProcess(1, 1, 1, "김치를 적당히 썰어서 냄비에 넣고 볶는다", "imagelink", null),
+                new RecipeProcess(2, 1, 2, "참치와 물과 소금을 넣고 팔팔 끓인다", "imagelink", "국물이 안 빨갛다면 김치국물 넣기"));
+    }
+
+    @Test
+    @DisplayName("레시피 정보 리스트 가져오기 성공")
+    void getRecipeInfoList_success() {
+        // given
+        Ingredient ingredient = Ingredient.builder()
+                .ingredientId(1)
+                .name("동원참치")
+                .category("참치통조림")
+                .build();
+        List<Integer> recipeCodeList = Arrays.asList(1);
+
+        given(ingredientRepository.findById(anyInt())).willReturn(Optional.of(ingredient));
+        given(ingredientCategoryRepository.findRecipeCodeByCategory(any(String.class))).willReturn(recipeCodeList);
+        given(recipeInfoRepository.findById(anyInt())).willReturn(Optional.of(info));
+
+        // when
+        int ingredientId = 1;
+        List<RecipeInfoResponseDto> infoList = recipeService.getRecipeInfoList(ingredientId);
+
+        // then
+        MatcherAssert.assertThat(infoList.size(), is(1));
+        MatcherAssert.assertThat(infoList.get(0).getRecipeCode(), is(info.getRecipeCode()));
+        MatcherAssert.assertThat(infoList.get(0).getRecipeName(), is(info.getRecipeName()));
+    }
+
+    @Test
+    @DisplayName("ingredientId에 해당하는 재료를 못 찾아서 레시피 정보 리스트 반환 실패")
+    void getRecipeInfoList_fail_INGREDIENT_NOT_FOUND() {
+        // given
+        given(ingredientRepository.findById(anyInt())).willThrow(new RestApiException(INGREDIENT_NOT_FOUND));
+
+        // when
+        int ingredientId = 1;
+
+        // then
+        RestApiException exception = assertThrows(RestApiException.class, () ->
+                recipeService.getRecipeInfoList(ingredientId)
+        );
+        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.NOT_FOUND));
+        MatcherAssert.assertThat(exception.getErrorCode().name(), is("INGREDIENT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("recipeCode에 해당하는 레시피가 없어서 레시피 정보 리스트 반환 실패")
+    void getRecipeInfoList_fail_RECIPE_NOT_FOUND() {
+        // given
+        Ingredient ingredient = Ingredient.builder()
+                .ingredientId(1)
+                .name("동원참치")
+                .category("참치통조림")
+                .build();
+        List<Integer> recipeCodeList = Arrays.asList(1);
+
+        given(ingredientRepository.findById(anyInt())).willReturn(Optional.of(ingredient));
+        given(ingredientCategoryRepository.findRecipeCodeByCategory(any(String.class))).willReturn(recipeCodeList);
+        given(recipeInfoRepository.findById(anyInt())).willThrow(new RestApiException(RECIPE_NOT_FOUND));
+
+        // when
+        int ingredientId = 1;
+
+        // then
+        RestApiException exception = assertThrows(RestApiException.class, () ->
+                recipeService.getRecipeInfoList(ingredientId)
+        );
+        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.NOT_FOUND));
+        MatcherAssert.assertThat(exception.getErrorCode().name(), is("RECIPE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("상세 레시피 가져오기 성공")
+    void getSpecificRecipe_success() {
+        // given
+        given(recipeInfoRepository.findById(anyInt())).willReturn(Optional.of(info));
+        given(recipeIngredientRepository.findByRecipeCodeOrderByIngredientNumber(anyInt())).willReturn(ingredientList);
+        given(recipeProcessRepository.findByRecipeCodeOrderByProcessNumber(anyInt())).willReturn(processList);
+
+        // when
+        int recipeCode = 1;
+        SpecificRecipeResponseDto dto = recipeService.getSpecificRecipe(recipeCode);
+
+        // then
+        MatcherAssert.assertThat(dto.getName(), is(info.getRecipeName()));
+        MatcherAssert.assertThat(dto.getSummary(), is(info.getSummary()));
+
+        MatcherAssert.assertThat(dto.getIngredient().size(), is(2));
+        MatcherAssert.assertThat(dto.getIngredient().get(0).getName(), is(ingredientList.get(0).getIngredientName()));
+        MatcherAssert.assertThat(dto.getIngredient().get(1).getName(), is(ingredientList.get(1).getIngredientName()));
+
+        MatcherAssert.assertThat(dto.getProcess().size(), is(2));
+        MatcherAssert.assertThat(dto.getProcess().get(0).getDescription(), is(processList.get(0).getDescription()));
+        MatcherAssert.assertThat(dto.getProcess().get(1).getDescription(), is(processList.get(1).getDescription()));
+    }
+
+    @Test
+    @DisplayName("recipeCode에 해당하는 레시피 못 찾아서 상세 레시피 가져오기 실패")
+    void getSpecificRecipe_fail_RECIPE_NOT_FOUND() {
+        // given
+        given(recipeInfoRepository.findById(anyInt())).willThrow(new RestApiException(RECIPE_NOT_FOUND));
+
+        // when
+        int recipeCode = 1;
+
+        // then
+        RestApiException exception = assertThrows(RestApiException.class, () ->
+                recipeService.getSpecificRecipe(recipeCode)
+        );
+        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.NOT_FOUND));
+        MatcherAssert.assertThat(exception.getErrorCode().name(), is("RECIPE_NOT_FOUND"));
+    }
+}


### PR DESCRIPTION
## 개요
- 레시피 추천 구현
- 초대 거절, 초대 알람 리스트 반환 구현

## 작업사항
- `/recipe/list/{ingredient_id)`로 get 요청이 오면 재료의 카테고리를 이용해 레시피를 검색하여 레시피 정보 리스트를 반환함.
- `/recipe/specific/{recipe_code}`로 get 요청이 오면 레시피 코드에 해당하는 레시피의 상세 정보를 반환함.
- `/reject/{alarm_id}`로 delete 요청이 오면 초대 거절로 간주하고 알람을 삭제함.
- `/get/alarms`로 get 요청이 오면 초대 알람 리스트를 반환함.
<br>

- 레시피 추천 구현을 위해 레시피 기본정보, 재료정보, 과정정보를 각각 디비의 `recipe_info`, `recipe_ingredient`, `recipe_process` 테이블에 넣음
- `MemberInvitaionService`의 `reject()`, `getAlarmList()` 단위 테스트 구현
- `RecipeService` 단위 테스트 구현

## 변경사항
- `RECIPE_NOT_FOUND` 에러 코드 정의