### PR TITLE
유통기한 알람 구현

### DIFF
--- a/src/main/java/com/example/naengtal/NaengtalApplication.java
+++ b/src/main/java/com/example/naengtal/NaengtalApplication.java
@@ -3,9 +3,11 @@ package com.example.naengtal;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class NaengtalApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/naengtal/domain/alarm/dto/FcmNotificationDto.java
+++ b/src/main/java/com/example/naengtal/domain/alarm/dto/FcmNotificationDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @Builder
-public class FcmInvitationDto {
+public class FcmNotificationDto {
 
     private String title;
     private String body;

--- a/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientRepository.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientRepository.java
@@ -5,10 +5,12 @@ import com.example.naengtal.domain.ingredient.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface IngredientRepository extends JpaRepository<Ingredient, Integer> {
 
     List<Ingredient> findByFridge(Fridge fridge);
+    List<Ingredient> findByExpirationDateLessThanEqualOrderByExpirationDate(LocalDate localDate);
 }

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/controller/IngredientAlarmApiController.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/controller/IngredientAlarmApiController.java
@@ -1,0 +1,38 @@
+package com.example.naengtal.domain.ingredientalarm.controller;
+
+import com.example.naengtal.domain.ingredientalarm.dto.IngredientAlarmResponseDto;
+import com.example.naengtal.domain.ingredientalarm.service.IngredientAlarmService;
+import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("ingredient/alarm/")
+public class IngredientAlarmApiController {
+
+    private final IngredientAlarmService ingredientAlarmService;
+
+    @GetMapping("get")
+    public ResponseEntity<List<IngredientAlarmResponseDto>> getIngredientAlarm(@Parameter(hidden = true) @LoggedInUser Member member) {
+        List<IngredientAlarmResponseDto> alarms = ingredientAlarmService.getAlarm(member);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(alarms);
+    }
+
+    @DeleteMapping("delete")
+    public ResponseEntity<String> deleteIngredientAlarm(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                        @RequestParam(name = "id") int id) {
+        ingredientAlarmService.deleteAlarm(member, id);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("success");
+    }
+}

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/dao/IngredientAlarmRepository.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/dao/IngredientAlarmRepository.java
@@ -1,0 +1,10 @@
+package com.example.naengtal.domain.ingredientalarm.dao;
+
+import com.example.naengtal.domain.ingredientalarm.entity.IngredientAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IngredientAlarmRepository extends JpaRepository<IngredientAlarm, Integer> {
+
+}

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/dao/IngredientAlarmRepository.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/dao/IngredientAlarmRepository.java
@@ -1,10 +1,14 @@
 package com.example.naengtal.domain.ingredientalarm.dao;
 
 import com.example.naengtal.domain.ingredientalarm.entity.IngredientAlarm;
+import com.example.naengtal.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface IngredientAlarmRepository extends JpaRepository<IngredientAlarm, Integer> {
 
+    List<IngredientAlarm> findByMemberOrderByCreatedAtDesc(Member member);
 }

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/dto/IngredientAlarmResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/dto/IngredientAlarmResponseDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public class IngredientAlarmResponseDto {
 
-    private int id;
+    private int alarmId;
 
     private String text;
 }

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/dto/IngredientAlarmResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/dto/IngredientAlarmResponseDto.java
@@ -11,5 +11,5 @@ public class IngredientAlarmResponseDto {
 
     private int alarmId;
 
-    private String text;
+    private String content;
 }

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/dto/IngredientAlarmResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/dto/IngredientAlarmResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.naengtal.domain.ingredientalarm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class IngredientAlarmResponseDto {
+
+    private int id;
+
+    private String text;
+}

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
@@ -1,13 +1,19 @@
 package com.example.naengtal.domain.ingredientalarm.entity;
 
 import com.example.naengtal.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
+@Getter
 @Table(name = "ingredient_alarm")
 public class IngredientAlarm {
 

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
@@ -20,7 +20,7 @@ public class IngredientAlarm {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "alarm_id", nullable = false)
-    private int alarm_id;
+    private int id;
 
     @Column(name = "text")
     private String text;

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
@@ -1,0 +1,28 @@
+package com.example.naengtal.domain.ingredientalarm.entity;
+
+import com.example.naengtal.domain.member.entity.Member;
+import lombok.Builder;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Table(name = "ingredient_alarm")
+public class IngredientAlarm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "alarm_id", nullable = false)
+    private int alarm_id;
+
+    @Column(name = "text")
+    private String text;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/entity/IngredientAlarm.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -15,6 +17,7 @@ import java.time.LocalDateTime;
 @Builder
 @Getter
 @Table(name = "ingredient_alarm")
+@EntityListeners(AuditingEntityListener.class)
 public class IngredientAlarm {
 
     @Id
@@ -25,6 +28,7 @@ public class IngredientAlarm {
     @Column(name = "text")
     private String text;
 
+    @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/exception/IngredientAlarmErrorCode.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/exception/IngredientAlarmErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.naengtal.domain.ingredientalarm.exception;
+
+import com.example.naengtal.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum IngredientAlarmErrorCode implements ErrorCode {
+
+    INGREDIENT_ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ingredient alarm not found");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
@@ -1,0 +1,96 @@
+package com.example.naengtal.domain.ingredientalarm.service;
+
+import com.example.naengtal.domain.alarm.dto.FcmNotificationDto;
+import com.example.naengtal.domain.fridge.entity.Fridge;
+import com.example.naengtal.domain.ingredient.dao.IngredientRepository;
+import com.example.naengtal.domain.ingredient.entity.Ingredient;
+import com.example.naengtal.domain.ingredientalarm.dao.IngredientAlarmRepository;
+import com.example.naengtal.domain.ingredientalarm.entity.IngredientAlarm;
+import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.common.service.FcmService;
+import com.example.naengtal.global.common.service.FcmType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ExpirationNotificationScheduler {
+
+    private final IngredientRepository ingredientRepository;
+    private final IngredientAlarmRepository ingredientAlarmRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final FcmService fcmService;
+    private LocalDate now;
+
+    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+    public void schedule() {
+        System.out.println("schedule");
+        now = LocalDate.now();
+
+        // 유통기한 임박 (D-5~D-day)
+        List<Ingredient> ingredients = ingredientRepository.findByExpirationDateLessThanEqualOrderByExpirationDate(now.plusDays(5));
+        sendAlarms(ingredients);
+    }
+
+    private void sendAlarms(List<Ingredient> ingredients) {
+        // db에 저장, fcm 알람 보냄
+        ingredients.forEach(ingredient -> {
+            saveAlarm(ingredient);
+            sendAlarm(ingredient);
+        });
+    }
+
+    private void saveAlarm(Ingredient ingredient) {
+        System.out.println(ingredient.getName());
+        String message = ingredient.getName() + " " + getMessage(getTimeDifference(ingredient.getExpirationDate()));
+
+        Fridge fridge = ingredient.getFridge();
+        List<Member> sharedMembers = fridge.getSharedMembers();
+
+        sharedMembers.stream()
+                .map(member -> IngredientAlarm.builder()
+                        .createdAt(LocalDateTime.now())
+                        .text(message)
+                        .member(member)
+                        .build())
+                .forEach(ingredientAlarmRepository::save);
+    }
+
+    private void sendAlarm(Ingredient ingredient) {
+        int timeDifference = getTimeDifference(ingredient.getExpirationDate());
+
+        fcmService.sendByTopic(String.valueOf(ingredient.getFridge().getId()), FcmNotificationDto.builder()
+                .title(getTitle(timeDifference))
+                .body(ingredient.getName() + getMessage(timeDifference))
+                .type(FcmType.EXPIRATION_DATE)
+                .build());
+    }
+
+    private String getMessage(int date) {
+        if (date < 0) {
+            return "의 유통기한이 지났어요.";
+        }
+        return "의 유통기한이 " + date + "일 남았어요.";
+    }
+
+    private String getTitle(int date) {
+        if (date < 0) {
+            return "유통기한 만료";
+        }
+        return "유통기한 임박";
+    }
+
+    private int getTimeDifference(LocalDate expirationDate) {
+        Period period = Period.between(now, expirationDate);
+        return period.getDays();
+    }
+}

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
@@ -10,7 +10,6 @@ import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.global.common.service.FcmService;
 import com.example.naengtal.global.common.service.FcmType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +26,6 @@ public class ExpirationNotificationScheduler {
 
     private final IngredientRepository ingredientRepository;
     private final IngredientAlarmRepository ingredientAlarmRepository;
-    private final RedisTemplate<String, String> redisTemplate;
     private final FcmService fcmService;
     private LocalDate now;
 

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
@@ -51,7 +51,7 @@ public class ExpirationNotificationScheduler {
 
     private void saveAlarm(Ingredient ingredient) {
         System.out.println(ingredient.getName());
-        String message = ingredient.getName() + " " + getMessage(getTimeDifference(ingredient.getExpirationDate()));
+        String message = ingredient.getName() + getMessage(getTimeDifference(ingredient.getExpirationDate()));
 
         Fridge fridge = ingredient.getFridge();
         List<Member> sharedMembers = fridge.getSharedMembers();

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
@@ -56,7 +56,6 @@ public class ExpirationNotificationScheduler {
 
         sharedMembers.stream()
                 .map(member -> IngredientAlarm.builder()
-                        .createdAt(LocalDateTime.now())
                         .text(message)
                         .member(member)
                         .build())

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationScheduler.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.List;
 
@@ -36,10 +35,6 @@ public class ExpirationNotificationScheduler {
 
         // 유통기한 임박 (D-5~D-day)
         List<Ingredient> ingredients = ingredientRepository.findByExpirationDateLessThanEqualOrderByExpirationDate(now.plusDays(5));
-        sendAlarms(ingredients);
-    }
-
-    private void sendAlarms(List<Ingredient> ingredients) {
         // db에 저장, fcm 알람 보냄
         ingredients.forEach(ingredient -> {
             saveAlarm(ingredient);

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmService.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmService.java
@@ -1,0 +1,46 @@
+package com.example.naengtal.domain.ingredientalarm.service;
+
+import com.example.naengtal.domain.ingredientalarm.dao.IngredientAlarmRepository;
+import com.example.naengtal.domain.ingredientalarm.dto.IngredientAlarmResponseDto;
+import com.example.naengtal.domain.ingredientalarm.entity.IngredientAlarm;
+import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.naengtal.domain.ingredientalarm.exception.IngredientAlarmErrorCode.INGREDIENT_ALARM_NOT_FOUND;
+import static com.example.naengtal.global.error.CommonErrorCode.FORBIDDEN;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class IngredientAlarmService {
+
+    private final IngredientAlarmRepository ingredientAlarmRepository;
+
+    public List<IngredientAlarmResponseDto> getAlarm(Member member) {
+        List<IngredientAlarm> alarms = ingredientAlarmRepository.findByMemberOrderByCreatedAtDesc(member);
+
+        return alarms.stream()
+                .map(alarm -> IngredientAlarmResponseDto.builder()
+                        .id(alarm.getId())
+                        .text(alarm.getText())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public void deleteAlarm(Member member, int id) {
+        IngredientAlarm alarm = ingredientAlarmRepository.findById(id).orElseThrow(() -> new RestApiException(INGREDIENT_ALARM_NOT_FOUND));
+
+        // 본인 알람이 아닐 때
+        if (!member.equals(alarm.getMember())) {
+            throw new RestApiException(FORBIDDEN);
+        }
+
+        ingredientAlarmRepository.delete(alarm);
+    }
+}

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmService.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmService.java
@@ -28,7 +28,7 @@ public class IngredientAlarmService {
         return alarms.stream()
                 .map(alarm -> IngredientAlarmResponseDto.builder()
                         .alarmId(alarm.getId())
-                        .text(alarm.getText())
+                        .content(alarm.getText())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmService.java
+++ b/src/main/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmService.java
@@ -27,7 +27,7 @@ public class IngredientAlarmService {
 
         return alarms.stream()
                 .map(alarm -> IngredientAlarmResponseDto.builder()
-                        .id(alarm.getId())
+                        .alarmId(alarm.getId())
                         .text(alarm.getText())
                         .build())
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/naengtal/domain/member/entity/Member.java
+++ b/src/main/java/com/example/naengtal/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.example.naengtal.domain.member.entity;
 
 import com.example.naengtal.domain.alarm.entity.Alarm;
 import com.example.naengtal.domain.fridge.entity.Fridge;
+import com.example.naengtal.domain.ingredientalarm.entity.IngredientAlarm;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,6 +39,8 @@ public class Member {
     @OneToMany(mappedBy = "inviter", orphanRemoval = true)
     private List<Alarm> relatedAlarms = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
+    private List<IngredientAlarm> ingredientAlarms = new ArrayList<>();
 
     @Builder
     public Member(String id, String name, String password, Fridge fridge) {

--- a/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
+++ b/src/main/java/com/example/naengtal/domain/member/service/AccountService.java
@@ -1,20 +1,22 @@
 package com.example.naengtal.domain.member.service;
 
-import com.example.naengtal.domain.fridge.entity.Fridge;
 import com.example.naengtal.domain.fridge.dao.FridgeRepository;
+import com.example.naengtal.domain.fridge.entity.Fridge;
 import com.example.naengtal.domain.ingredient.dao.IngredientRepository;
-import com.example.naengtal.domain.ingredient.service.IngredientService;
 import com.example.naengtal.domain.member.dao.MemberRepository;
 import com.example.naengtal.domain.member.dto.MemberInfo;
 import com.example.naengtal.domain.member.dto.SignUpRequestDto;
 import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.common.service.FcmService;
 import com.example.naengtal.global.common.service.S3Uploader;
 import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 import static com.example.naengtal.domain.member.exception.MemberErrorCode.UNAVAILABLE_ID;
 import static com.example.naengtal.domain.member.exception.MemberErrorCode.WRONG_CONFIRM_PASSWORD;
@@ -33,6 +35,10 @@ public class AccountService {
     private final IngredientRepository ingredientRepository;
 
     private final S3Uploader s3Uploader;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final FcmService fcmService;
 
     public MemberInfo saveMember(SignUpRequestDto signUpRequestDto) {
         // id 중복 검사
@@ -63,14 +69,15 @@ public class AccountService {
         // fridge 에 속한 재료들의 이미지 삭제
         Fridge fridge = member.getFridge();
         ingredientRepository.findByFridge(fridge)
-                        .forEach(ingredient ->
-                                s3Uploader.deleteFile(ingredient.getImage()));
+                .forEach(ingredient ->
+                        s3Uploader.deleteFile(ingredient.getImage()));
 
         if (fridge.getSharedMembers().size() == 1) {
             fridgeRepository.delete(fridge);
         }
 
         memberRepository.delete(member);
+        fcmService.unsubscribeFridge(member, getTokenList(member));
     }
 
     public void editName(Member member, String name) {
@@ -82,5 +89,9 @@ public class AccountService {
                 .name(member.getName())
                 .id(member.getId())
                 .build();
+    }
+
+    private List<String> getTokenList(Member member) {
+        return redisTemplate.opsForList().range(member.getId(), 0, -1);
     }
 }

--- a/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/com/example/naengtal/global/auth/controller/AuthenticationApiController.java
@@ -36,7 +36,7 @@ public class AuthenticationApiController {
     private ResponseEntity<String> signOut(@Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
                                            @Parameter(hidden = true) @LoggedInUser Member member,
                                            @RequestParam("fcmtoken") String fcmToken) {
-        authenticationService.signOut(authorization.substring(BEARER_PREFIX.length()), member.getId(), fcmToken);
+        authenticationService.signOut(authorization.substring(BEARER_PREFIX.length()), member, fcmToken);
         return ResponseEntity.status(HttpStatus.OK)
                 .body("signout success!");
     }

--- a/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
+++ b/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
@@ -40,12 +40,13 @@ public class AuthenticationService {
         Authentication authentication = getAuthentication(authenticationToken);
 
         // fcm token 저장
-        if (fcmToken != null)
+        if (fcmToken != null){
             redisTemplate.opsForList().rightPush(id, fcmToken);
 
-        // fcm 냉장고 구독
-        Member member = memberRepository.findById(id).orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
-        fcmService.subscribeFridge(member, Collections.singletonList(fcmToken));
+            // fcm 냉장고 구독
+            Member member = memberRepository.findById(id).orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+            fcmService.subscribeFridge(member, Collections.singletonList(fcmToken));
+        }
 
         return jwtTokenProvider.generateToken(authentication);
     }
@@ -65,9 +66,9 @@ public class AuthenticationService {
                         jwtTokenProvider.getExpiration(accessToken) - (new Date()).getTime(),
                         TimeUnit.MILLISECONDS);
 
-        if (fcmToken != null)
+        if (fcmToken != null){
             redisTemplate.opsForList().remove(member.getId(), 0, fcmToken);
-
-        fcmService.unsubscribeFridge(member, Collections.singletonList(fcmToken));
+            fcmService.unsubscribeFridge(member, Collections.singletonList(fcmToken));
+        }
     }
 }

--- a/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
+++ b/src/main/java/com/example/naengtal/global/auth/service/AuthenticationService.java
@@ -1,7 +1,10 @@
 package com.example.naengtal.global.auth.service;
 
+import com.example.naengtal.domain.member.dao.MemberRepository;
+import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.global.auth.dto.TokenDto;
 import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
+import com.example.naengtal.global.common.service.FcmService;
 import com.example.naengtal.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -11,9 +14,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import static com.example.naengtal.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.example.naengtal.global.auth.exception.AuthErrorCode.WRONG_ID_OR_PASSWORD;
 
 @Service
@@ -24,6 +29,8 @@ public class AuthenticationService {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final RedisTemplate<String, String> redisTemplate;
+    private final MemberRepository memberRepository;
+    private final FcmService fcmService;
 
     public TokenDto signIn(String id, String password, String fcmToken) {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, password);
@@ -36,6 +43,10 @@ public class AuthenticationService {
         if (fcmToken != null)
             redisTemplate.opsForList().rightPush(id, fcmToken);
 
+        // fcm 냉장고 구독
+        Member member = memberRepository.findById(id).orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+        fcmService.subscribeFridge(member, Collections.singletonList(fcmToken));
+
         return jwtTokenProvider.generateToken(authentication);
     }
 
@@ -47,7 +58,7 @@ public class AuthenticationService {
         }
     }
 
-    public void signOut(String accessToken, String memberId, String fcmToken) {
+    public void signOut(String accessToken, Member member, String fcmToken) {
         redisTemplate.opsForValue()
                 .set(accessToken,
                         "signOut",
@@ -55,6 +66,8 @@ public class AuthenticationService {
                         TimeUnit.MILLISECONDS);
 
         if (fcmToken != null)
-            redisTemplate.opsForList().remove(memberId, 0, fcmToken);
+            redisTemplate.opsForList().remove(member.getId(), 0, fcmToken);
+
+        fcmService.unsubscribeFridge(member, Collections.singletonList(fcmToken));
     }
 }

--- a/src/main/java/com/example/naengtal/global/common/service/FcmType.java
+++ b/src/main/java/com/example/naengtal/global/common/service/FcmType.java
@@ -3,5 +3,5 @@ package com.example.naengtal.global.common.service;
 public enum FcmType {
 
     INVITATION,
-    CLOSE_TO_EXPIRATION
+    EXPIRATION_DATE,
 }

--- a/src/test/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationSchedulerTest.java
+++ b/src/test/java/com/example/naengtal/domain/ingredientalarm/service/ExpirationNotificationSchedulerTest.java
@@ -1,0 +1,103 @@
+package com.example.naengtal.domain.ingredientalarm.service;
+
+import com.example.naengtal.domain.fridge.dao.FridgeRepository;
+import com.example.naengtal.domain.fridge.entity.Fridge;
+import com.example.naengtal.domain.ingredient.dao.IngredientRepository;
+import com.example.naengtal.domain.ingredient.entity.Ingredient;
+import com.example.naengtal.domain.ingredientalarm.dao.IngredientAlarmRepository;
+import com.example.naengtal.domain.ingredientalarm.entity.IngredientAlarm;
+import com.example.naengtal.domain.member.dao.MemberRepository;
+import com.example.naengtal.domain.member.entity.Member;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+class ExpirationNotificationSchedulerTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private IngredientRepository ingredientRepository;
+    @Autowired
+    private FridgeRepository fridgeRepository;
+    @Autowired
+    private ExpirationNotificationScheduler expirationNotificationScheduler;
+    @Autowired
+    private IngredientAlarmRepository ingredientAlarmRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        // 냉장고 생성
+        Fridge fridge = new Fridge(1);
+        fridgeRepository.save(fridge);
+
+        // 회원 가입
+        Member member = Member.builder()
+                .name("test")
+                .id("test")
+                .password("test1234")
+                .fridge(fridge)
+                .build();
+
+        memberRepository.save(member);
+
+        Ingredient ingredient1 = Ingredient.builder()
+                .name("재료1")
+                .category("분류1")
+                .expirationDate(LocalDate.now().plusDays(1))
+                .image("image")
+                .fridge(fridge)
+                .build();
+        Ingredient ingredient2 = Ingredient.builder()
+                .name("재료2")
+                .category("분류2")
+                .expirationDate(LocalDate.now())
+                .image("image")
+                .fridge(fridge)
+                .build();
+        Ingredient ingredient3 = Ingredient.builder()
+                .name("재료3")
+                .category("분류3")
+                .expirationDate(LocalDate.now().minusDays(1))
+                .image("image")
+                .fridge(fridge)
+                .build();
+
+        ingredientRepository.save(ingredient1);
+        ingredientRepository.save(ingredient2);
+        ingredientRepository.save(ingredient3);
+    }
+
+    @AfterEach
+    void afterEach(){
+        ingredientRepository.deleteAll();
+        memberRepository.deleteAll();
+        fridgeRepository.deleteAll();
+    }
+
+    @Test
+    void scheduler_send_alarm_success() {
+        expirationNotificationScheduler.schedule();
+
+        IngredientAlarm ingredientAlarm1 = ingredientAlarmRepository.findById(1).orElse(null);
+        assertThat(ingredientAlarm1).isNotNull();
+        assertThat(ingredientAlarm1.getText()).isEqualTo("재료3의 유통기한이 지났어요.");
+        assertThat(ingredientAlarm1.getMember().getId()).isEqualTo("test");
+
+        IngredientAlarm ingredientAlarm2 = ingredientAlarmRepository.findById(2).orElse(null);
+        assertThat(ingredientAlarm2).isNotNull();
+        assertThat(ingredientAlarm2.getText()).isEqualTo("재료2의 유통기한이 0일 남았어요.");
+
+        IngredientAlarm ingredientAlarm3 = ingredientAlarmRepository.findById(3).orElse(null);
+        assertThat(ingredientAlarm3).isNotNull();
+        assertThat(ingredientAlarm3.getText()).isEqualTo("재료1의 유통기한이 1일 남았어요.");
+    }
+}

--- a/src/test/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmServiceTest.java
+++ b/src/test/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmServiceTest.java
@@ -60,7 +60,7 @@ class IngredientAlarmServiceTest {
 
         List<IngredientAlarmResponseDto> alarms = ingredientAlarmService.getAlarm(member);
 
-        assertThat(alarms.get(0).getText()).isEqualTo("~의 유통기한이 만료되었어요.");
+        assertThat(alarms.get(0).getContent()).isEqualTo("~의 유통기한이 만료되었어요.");
     }
 
 

--- a/src/test/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmServiceTest.java
+++ b/src/test/java/com/example/naengtal/domain/ingredientalarm/service/IngredientAlarmServiceTest.java
@@ -1,0 +1,108 @@
+package com.example.naengtal.domain.ingredientalarm.service;
+
+import com.example.naengtal.domain.fridge.entity.Fridge;
+import com.example.naengtal.domain.ingredientalarm.dao.IngredientAlarmRepository;
+import com.example.naengtal.domain.ingredientalarm.dto.IngredientAlarmResponseDto;
+import com.example.naengtal.domain.ingredientalarm.entity.IngredientAlarm;
+import com.example.naengtal.domain.member.entity.Member;
+import com.example.naengtal.global.error.RestApiException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.naengtal.domain.ingredientalarm.exception.IngredientAlarmErrorCode.INGREDIENT_ALARM_NOT_FOUND;
+import static com.example.naengtal.global.error.CommonErrorCode.FORBIDDEN;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class IngredientAlarmServiceTest {
+
+    @InjectMocks
+    private IngredientAlarmService ingredientAlarmService;
+
+    @Mock
+    private IngredientAlarmRepository ingredientAlarmRepository;
+
+    private Member member;
+
+    private IngredientAlarm alarm;
+
+    @BeforeEach
+    void before() {
+        Fridge fridge = new Fridge(1);
+        member = Member.builder()
+                .id("test")
+                .password("test1234")
+                .fridge(fridge)
+                .build();
+
+        alarm = IngredientAlarm.builder()
+                .id(1)
+                .member(member)
+                .text("~의 유통기한이 만료되었어요.")
+                .build();
+    }
+
+    @Test
+    @DisplayName("유통기한 알람 조회 성공")
+    public void get_alarm_success() {
+        given(ingredientAlarmRepository.findByMemberOrderByCreatedAtDesc(any(Member.class))).willReturn(List.of(alarm));
+
+        List<IngredientAlarmResponseDto> alarms = ingredientAlarmService.getAlarm(member);
+
+        assertThat(alarms.get(0).getText()).isEqualTo("~의 유통기한이 만료되었어요.");
+    }
+
+
+    @Test
+    @DisplayName("유통기한 알람 삭제 성공")
+    void delete_alarm_success() {
+        given(ingredientAlarmRepository.findById(any(Integer.class))).willReturn(Optional.of(alarm));
+
+        ingredientAlarmService.deleteAlarm(member, 1);
+    }
+
+    @Test
+    @DisplayName("본인 알람이 아닐 시 삭제 실패")
+    void delete_alarm_fail_when_not_mine() {
+        Fridge fridge = new Fridge(1);
+        Member member = Member.builder()
+                .id("test2")
+                .password("test1234")
+                .fridge(fridge)
+                .build();
+        given(ingredientAlarmRepository.findById(any(Integer.class))).willReturn(Optional.of(alarm));
+
+        RestApiException exception = assertThrows(RestApiException.class, () ->
+                ingredientAlarmService.deleteAlarm(member, 1));
+
+        assertThat(exception.getErrorCode()).isEqualTo(FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 알림일 시 삭제 실패")
+    void delete_alarm_fail_when_not_exist(){
+        Fridge fridge = new Fridge(1);
+        Member member = Member.builder()
+                .id("test1")
+                .password("test1234")
+                .fridge(fridge)
+                .build();
+        given(ingredientAlarmRepository.findById(any(Integer.class))).willReturn(Optional.empty());
+
+        RestApiException exception = assertThrows(RestApiException.class, () ->
+                ingredientAlarmService.deleteAlarm(member, 1));
+
+        assertThat(exception.getErrorCode()).isEqualTo(INGREDIENT_ALARM_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/example/naengtal/global/auth/SecurityTest.java
+++ b/src/test/java/com/example/naengtal/global/auth/SecurityTest.java
@@ -1,7 +1,9 @@
 package com.example.naengtal.global.auth;
 
+import com.example.naengtal.domain.fridge.entity.Fridge;
 import com.example.naengtal.domain.member.dao.MemberRepository;
 import com.example.naengtal.domain.member.dto.SignUpRequestDto;
+import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.domain.member.service.AccountService;
 import com.example.naengtal.global.auth.jwt.JwtTokenProvider;
 import com.example.naengtal.global.auth.service.AuthenticationService;
@@ -147,8 +149,13 @@ public class SecurityTest {
         String accessToken = authenticationService.signIn("test", "test1234", null).getAccessToken();
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken);
-
-        authenticationService.signOut(accessToken, "test",null);
+        Member member = Member.builder()
+                .name("test")
+                .id("test")
+                .password("test1234")
+                .fridge(new Fridge(1))
+                .build();
+        authenticationService.signOut(accessToken, member, null);
 
 
         mockMvc.perform(post("/auth/signout")


### PR DESCRIPTION
## 개요
- 매일 아침 8시마다 유통기한(~D-5)까지 알림 주는 기능 구현
- 알림 조회/삭제 구현

## 작업사항
- @Scheduled 사용해서 매일 아침 8시마다 ExpirationNotificationScheduler.schedule() 실행하게 함
    -> schedule() 실행 시 DB에 알림 저장, FCM으로 알림 보냄
    -> FCM 알림은 토픽으로 보내는 것을 사용함(안될 시 토큰으로 수정 예정)
    ```
    {
      "message":{
        "topic":"fridge_id",
        "notification":{
          "title":"유통기한 임박 | 유통기한 만료",
          "body":"~의 유통기한이 지났어요 | ~일 남았어요."
        },
        "data" : {
          "type" : "EXPIRATION_DATE"
        }
      }
    }
    ```
- '/ingredient/alarm/get'으로 요청 시 알림 조회
- '/ingredient/alarm/delete?id=~'로 요청 시 알림 삭제
- schedule()은 MockitoExtension.class 로 테스트하기에 한계가 있어서 @SpringBootTest 사용하여 테스트 구현함. 나머지는 MockitoExtension.class 로 구현

## 변경로직
- FcmInvitationDto 클래스 이름 FcmNotificationDto로 변경 
- INGREDIENT_ALARM_NOT_FOUND (404) 에러코드 추가
