### PR TITLE
재료 조회, 개수 정보 주는 기능 구현

### DIFF
--- a/src/main/java/com/example/naengtal/domain/ingredient/controller/IngredientApiController.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/controller/IngredientApiController.java
@@ -1,5 +1,6 @@
 package com.example.naengtal.domain.ingredient.controller;
 
+import com.example.naengtal.domain.ingredient.dto.IngredientCountResponseDto;
 import com.example.naengtal.domain.ingredient.dto.IngredientRequestDto;
 import com.example.naengtal.domain.ingredient.dto.IngredientResponseDto;
 import com.example.naengtal.domain.ingredient.service.IngredientService;
@@ -36,11 +37,20 @@ public class IngredientApiController {
     }
 
     @GetMapping("get")
-    public ResponseEntity<List<IngredientResponseDto>> getIngredients(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<IngredientResponseDto> ingredients = ingredientService.getIngredients(member);
+    public ResponseEntity<List<IngredientResponseDto>> getIngredients(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                                      @RequestParam(name = "orderby") String string) {
+        List<IngredientResponseDto> ingredients = ingredientService.getIngredients(member, string);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ingredients);
+    }
+
+    @GetMapping("get/count")
+    public ResponseEntity<IngredientCountResponseDto> getIngredientCount(@Parameter(hidden = true) @LoggedInUser Member member) {
+        IngredientCountResponseDto count = ingredientService.getIngredientCount(member);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(count);
     }
 
     @DeleteMapping("delete")

--- a/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientRepository.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/dao/IngredientRepository.java
@@ -12,5 +12,14 @@ import java.util.List;
 public interface IngredientRepository extends JpaRepository<Ingredient, Integer> {
 
     List<Ingredient> findByFridge(Fridge fridge);
+
+    List<Ingredient> findByFridgeOrderByIngredientIdDesc(Fridge fridge);
+
+    List<Ingredient> findByFridgeOrderByExpirationDate(Fridge fridge);
+
+    int countByFridgeAndExpirationDateLessThanEqual(Fridge fridge, LocalDate localDate);
+
+    int countByFridgeAndExpirationDateBetween(Fridge fridge, LocalDate start, LocalDate end);
+
     List<Ingredient> findByExpirationDateLessThanEqualOrderByExpirationDate(LocalDate localDate);
 }

--- a/src/main/java/com/example/naengtal/domain/ingredient/dto/IngredientCountResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/dto/IngredientCountResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.naengtal.domain.ingredient.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class IngredientCountResponseDto {
+
+    private int approachingIngredients;
+    private int expiredIngredients;
+}

--- a/src/main/java/com/example/naengtal/domain/ingredient/dto/IngredientResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/ingredient/dto/IngredientResponseDto.java
@@ -22,4 +22,6 @@ public class IngredientResponseDto {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
     private LocalDate expirationDate;
+
+    private boolean expirationDatePassed;
 }


### PR DESCRIPTION
## 개요
- 재료 임박순, 최신순으로 정렬하여 조회해주는 기능 구현
- 임박한 재료 개수, 유통기한 만료된 재료 개수 리턴 기능 구현

## 작업사항
- `/ingredient/get?orderby=(newest | expiration)`으로 접근 시 재료를 정렬하여 리턴해준다. newest는 최신순, expiration은 유통기한 만료 임박순
- `/ingredient/get/count`으로 접근 시 임박한 재료 개수, 유통기한 만료된 재료개수를 리턴해준다.

## 변경로직
- 재료정보 리턴 시 유통기한 만료 유무 정보 추가
- 조회방법 변경에 따른 테스트 코드 변경
