### PR TITLE
이미지 업로드 최대 크기 설정

### DIFF
--- a/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
+++ b/src/main/java/com/example/naengtal/global/error/CommonErrorCode.java
@@ -13,7 +13,8 @@ public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal server error"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden"),
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "image upload fail"),
-    ONLY_IMAGE_ALLOWED(HttpStatus.BAD_REQUEST, "only image are allowed for upload");
+    ONLY_IMAGE_ALLOWED(HttpStatus.BAD_REQUEST, "only image are allowed for upload"),
+    IMAGE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "image is too large");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/naengtal/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/naengtal/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -11,6 +12,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RestApiException.class)
     public ResponseEntity<ErrorResponseDto> handleRestApiException(RestApiException e) {
         ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponseDto> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        ErrorCode errorCode = CommonErrorCode.IMAGE_TOO_LARGE;
         return handleExceptionInternal(errorCode);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
   redis:
     host: localhost
     port: 6379
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 jwt:
   secret: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 개요
- 이미지 업로드 시 최대크기 10MB로 설정
- 10MB 초과 시 에러 처리

## 변경로직
- `application.yml`에 설정 추가
- `GlobalExceptionHandler`에 `MaxUploadSizeExceededException`발생 시 `IMAGE_TOO_LARGE` 에러 발생하게 설정
