### PR TITLE
레시피 재료 정보 반환 수정

### DIFF
--- a/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/controller/RecipeRecommandationApiController.java
@@ -1,8 +1,11 @@
 package com.example.naengtal.domain.recipe.controller;
 
+import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.domain.recipe.dto.RecipeInfoResponseDto;
 import com.example.naengtal.domain.recipe.dto.SpecificRecipeResponseDto;
 import com.example.naengtal.domain.recipe.service.RecipeService;
+import com.example.naengtal.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,8 +27,9 @@ public class RecipeRecommandationApiController {
     }
 
     @GetMapping("specific/{recipe_code}")
-    public ResponseEntity<SpecificRecipeResponseDto> getSpecificRecipe(@PathVariable("recipe_code") int recipeCode) {
+    public ResponseEntity<SpecificRecipeResponseDto> getSpecificRecipe(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                                       @PathVariable("recipe_code") int recipeCode) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(recipeService.getSpecificRecipe(recipeCode));
+                .body(recipeService.getSpecificRecipe(member, recipeCode));
     }
 }

--- a/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeIngredientResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dto/RecipeIngredientResponseDto.java
@@ -1,12 +1,12 @@
 package com.example.naengtal.domain.recipe.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @Builder
+@NoArgsConstructor
 public class RecipeIngredientResponseDto {
 
     private String name;
@@ -14,4 +14,6 @@ public class RecipeIngredientResponseDto {
     private String amount;
 
     private String type;
+
+    private boolean isContained;
 }

--- a/src/main/java/com/example/naengtal/domain/recipe/dto/SpecificRecipeResponseDto.java
+++ b/src/main/java/com/example/naengtal/domain/recipe/dto/SpecificRecipeResponseDto.java
@@ -27,7 +27,9 @@ public class SpecificRecipeResponseDto {
 
     private String difficulty;
 
-    private List<RecipeIngredientResponseDto> ingredient;
+    private List<RecipeIngredientResponseDto> mainIngredient;
+
+    private List<RecipeIngredientResponseDto> additionalIngredient;
 
     private List<RecipeProcessResponseDto> process;
 }

--- a/src/test/java/com/example/naengtal/domain/member/service/AccountServiceTest.java
+++ b/src/test/java/com/example/naengtal/domain/member/service/AccountServiceTest.java
@@ -19,8 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -67,8 +66,8 @@ class AccountServiceTest {
         MemberInfo memberInfo = accountService.saveMember(signUpRequestDto);
 
         // then
-        assertThat(memberInfo.getId(), is(member.getId()));
-        assertThat(memberInfo.getName(), is(member.getName()));
+        assertEquals(memberInfo.getId(), member.getId());
+        assertEquals(memberInfo.getName(), member.getName());
         then(passwordEncoder).should(times(1)).encode(any());
     }
 
@@ -97,8 +96,8 @@ class AccountServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 accountService.saveMember(signUpRequestDto)
         );
-        assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.BAD_REQUEST));
-        assertThat(exception.getErrorCode().name(), is("UNAVAILABLE_ID"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getErrorCode().name(), "UNAVAILABLE_ID");
     }
 
     @Test
@@ -118,8 +117,8 @@ class AccountServiceTest {
         );
 
         // then
-        assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.BAD_REQUEST));
-        assertThat(exception.getErrorCode().name(), is("WRONG_CONFIRM_PASSWORD"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getErrorCode().name(), "WRONG_CONFIRM_PASSWORD");
     }
 
     @Test

--- a/src/test/java/com/example/naengtal/domain/member/service/MemberInvitationServiceTest.java
+++ b/src/test/java/com/example/naengtal/domain/member/service/MemberInvitationServiceTest.java
@@ -10,7 +10,6 @@ import com.example.naengtal.domain.member.dao.MemberRepository;
 import com.example.naengtal.domain.member.entity.Member;
 import com.example.naengtal.global.common.service.FcmService;
 import com.example.naengtal.global.error.RestApiException;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +20,6 @@ import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -29,7 +27,7 @@ import java.util.Optional;
 import static com.example.naengtal.domain.alarm.exception.AlarmErrorCode.ALARM_NOT_FOUND;
 import static com.example.naengtal.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -71,8 +69,7 @@ class MemberInvitationServiceTest {
                 .password("encodedPassword")
                 .fridge(fridge1)
                 .build();
-        List<String> tokenList = new ArrayList<>();
-        tokenList.add("fcmtoken");
+        List<String> tokenList = Arrays.asList("fcmtoken");
 
         given(memberRepository.findById(any(String.class))).willReturn(Optional.of(invitee));
         given(redisTemplate.opsForList()).willReturn(listOperations);
@@ -115,8 +112,8 @@ class MemberInvitationServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 memberInvitationService.invite(inviter, inviteeId)
         );
-        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.NOT_FOUND));
-        MatcherAssert.assertThat(exception.getErrorCode().name(), is("MEMBER_NOT_FOUND"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.NOT_FOUND);
+        assertEquals(exception.getErrorCode().name(), "MEMBER_NOT_FOUND");
     }
 
     @Test
@@ -139,8 +136,8 @@ class MemberInvitationServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 memberInvitationService.invite(inviter, inviteeId)
         );
-        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.BAD_REQUEST));
-        MatcherAssert.assertThat(exception.getErrorCode().name(), is("CANNOT_INVITE_SELF"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getErrorCode().name(), "CANNOT_INVITE_SELF");
     }
 
     @Test
@@ -169,8 +166,8 @@ class MemberInvitationServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 memberInvitationService.invite(inviter, inviteeId)
         );
-        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.BAD_REQUEST));
-        MatcherAssert.assertThat(exception.getErrorCode().name(), is("ALREADY_SHARING"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getErrorCode().name(), "ALREADY_SHARING");
     }
 
     @Test
@@ -202,7 +199,9 @@ class MemberInvitationServiceTest {
                 .inviter(inviter)
                 .text(inviter.getName() + " 님이 냉장고 초대 요청을 보냈습니다.")
                 .build();
+        List<String> tokenList = Arrays.asList("fcmtoken");
 
+        given(redisTemplate.opsForList()).willReturn(listOperations);
         given(alarmRepository.findById(anyInt())).willReturn(Optional.of(alarm));
 
         // when
@@ -210,8 +209,8 @@ class MemberInvitationServiceTest {
         memberInvitationService.accept(invitee, alarmId);
 
         // then
-        MatcherAssert.assertThat(invitee.getFridge(), is(inviter.getFridge()));
-        MatcherAssert.assertThat(member.getFridge(), is(fridge1));
+        assertEquals(invitee.getFridge(), inviter.getFridge());
+        assertEquals(member.getFridge(), fridge1);
         then(alarmRepository).should(times(1)).delete(any(Alarm.class));
     }
 
@@ -238,7 +237,9 @@ class MemberInvitationServiceTest {
                 .inviter(inviter)
                 .text(inviter.getName() + " 님이 냉장고 초대 요청을 보냈습니다.")
                 .build();
+        List<String> tokenList = Arrays.asList("fcmtoken");
 
+        given(redisTemplate.opsForList()).willReturn(listOperations);
         given(alarmRepository.findById(anyInt())).willReturn(Optional.of(alarm));
 
         // when
@@ -246,7 +247,7 @@ class MemberInvitationServiceTest {
         memberInvitationService.accept(invitee, alarmId);
 
         // then
-        MatcherAssert.assertThat(invitee.getFridge(), is(inviter.getFridge()));
+        assertEquals(invitee.getFridge(), inviter.getFridge());
         then(alarmRepository).should(times(1)).delete(any(Alarm.class));
     }
 
@@ -270,8 +271,8 @@ class MemberInvitationServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 memberInvitationService.accept(invitee, alarmId)
         );
-        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.NOT_FOUND));
-        MatcherAssert.assertThat(exception.getErrorCode().name(), is("ALARM_NOT_FOUND"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.NOT_FOUND);
+        assertEquals(exception.getErrorCode().name(), "ALARM_NOT_FOUND");
     }
 
     @Test
@@ -313,8 +314,8 @@ class MemberInvitationServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 memberInvitationService.accept(invitee1, alarmId)
         );
-        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.BAD_REQUEST));
-        MatcherAssert.assertThat(exception.getErrorCode().name(), is("NOT_OWN_ALARM"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getErrorCode().name(), "NOT_OWN_ALARM");
     }
 
     @Test
@@ -327,6 +328,9 @@ class MemberInvitationServiceTest {
                 .password("encodedPassword")
                 .fridge(fridge)
                 .build();
+        List<String> tokenList = Arrays.asList("fcmtoken");
+
+        given(redisTemplate.opsForList()).willReturn(listOperations);
 
         memberInvitationService.leaveFridge(member);
 
@@ -349,6 +353,9 @@ class MemberInvitationServiceTest {
                 .password("encodedPassword")
                 .fridge(fridge)
                 .build();
+        List<String> tokenList = Arrays.asList("fcmtoken");
+
+        given(redisTemplate.opsForList()).willReturn(listOperations);
 
         memberInvitationService.leaveFridge(member1);
 
@@ -410,8 +417,8 @@ class MemberInvitationServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 memberInvitationService.reject(invitee, alarmId)
         );
-        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.NOT_FOUND));
-        MatcherAssert.assertThat(exception.getErrorCode().name(), is("ALARM_NOT_FOUND"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.NOT_FOUND);
+        assertEquals(exception.getErrorCode().name(), "ALARM_NOT_FOUND");
     }
 
     @Test
@@ -453,8 +460,8 @@ class MemberInvitationServiceTest {
         RestApiException exception = assertThrows(RestApiException.class, () ->
                 memberInvitationService.reject(invitee1, alarmId)
         );
-        MatcherAssert.assertThat(exception.getErrorCode().getHttpStatus(), is(HttpStatus.BAD_REQUEST));
-        MatcherAssert.assertThat(exception.getErrorCode().name(), is("NOT_OWN_ALARM"));
+        assertEquals(exception.getErrorCode().getHttpStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getErrorCode().name(), "NOT_OWN_ALARM");
     }
 
     @Test
@@ -486,8 +493,8 @@ class MemberInvitationServiceTest {
         List<AlarmResponseDto> dtoList = memberInvitationService.getAlarmList(invitee);
 
         // then
-        MatcherAssert.assertThat(dtoList.size(), is(1));
-        MatcherAssert.assertThat(dtoList.get(0).getAlarmId(), is(alarm.getId()));
-        MatcherAssert.assertThat(dtoList.get(0).getContent(), is(alarm.getText()));
+        assertEquals(dtoList.size(), 1);
+        assertEquals(dtoList.get(0).getAlarmId(), alarm.getId());
+        assertEquals(dtoList.get(0).getContent(), alarm.getText());
     }
 }

--- a/src/test/java/com/example/naengtal/domain/member/service/MemberSearchServiceTest.java
+++ b/src/test/java/com/example/naengtal/domain/member/service/MemberSearchServiceTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -60,10 +61,10 @@ class MemberSearchServiceTest {
         List<MemberResponseDto> searchedList = memberSearchService.search(inviter, nameOrId);
 
         // then
-        MatcherAssert.assertThat(searchedList.size(), is(2));
-        MatcherAssert.assertThat(searchedList.get(0).getId(), is(member1.getId()));
-        MatcherAssert.assertThat(searchedList.get(0).isSharing(), is(true));
-        MatcherAssert.assertThat(searchedList.get(1).getId(), is(member2.getId()));
-        MatcherAssert.assertThat(searchedList.get(1).isSharing(), is(false));
+        assertEquals(searchedList.size(), 2);
+        assertEquals(searchedList.get(0).getId(), member1.getId());
+        assertTrue(searchedList.get(0).isSharing());
+        assertEquals(searchedList.get(1).getId(), member2.getId());
+        assertFalse(searchedList.get(1).isSharing());
     }
 }


### PR DESCRIPTION
## 개요
레시피 재료 정보 반환 시 주재료 소유 여부 반환하도록 수정

## 작업사항
- 재료 정보 반환 시 주재료와 부재료 리스트 분리 (mainIngredient, additionalIngredient)
- 주재료의 경우 소유하고 있으면 isContained 값이 true. 소유하고 있지 않거나 주재료가 아닌 경우 false 값을 가짐.

## 변경로직
- 재료 정보 반환 값 변경에 따라 관련된 테스트 코드 수정.
- 테스트 코드에서 hamcrest의 assertThat() 함수가 사용된 부분을 junit jupiter api의 assertEqual(), assertTrue(), assertFalse()로 변경.
- MemberInvitationServiceTest에서 redisTemplate에 given 값이 주어지지 않아 발생하는 에러 수정.